### PR TITLE
修复编辑词条附加信息时，偶发性丢失关联词条数据的Bug

### DIFF
--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/EntriesAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/EntriesAPIController.cs
@@ -521,8 +521,14 @@ namespace CnGalWebSite.APIServer.Controllers
             }
 
             //查找词条
-            var currentEntry = await _entryRepository.GetAll().Include(s => s.Information).ThenInclude(s => s.Additional).FirstOrDefaultAsync(x => x.Id == model.Id);
-            var newEntry = await _entryRepository.GetAll().AsNoTracking().Include(s => s.Information).ThenInclude(s => s.Additional).FirstOrDefaultAsync(x => x.Id == model.Id);
+            var currentEntry = await _entryRepository.GetAll()
+                .Include(s => s.Information).ThenInclude(s => s.Additional)
+                .Include(s => s.EntryRelationFromEntryNavigation).ThenInclude(s => s.ToEntryNavigation)
+                .FirstOrDefaultAsync(x => x.Id == model.Id);
+            var newEntry = await _entryRepository.GetAll().AsNoTracking()
+                .Include(s => s.Information).ThenInclude(s => s.Additional)
+                .Include(s => s.EntryRelationFromEntryNavigation).ThenInclude(s => s.ToEntryNavigation)
+                .FirstOrDefaultAsync(x => x.Id == model.Id);
             if (currentEntry == null)
             {
                 return new Result { Error = $"无法找到ID为{model.Id}的词条", Successful = false };

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/ExaminesAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/ExaminesAPIController.cs
@@ -334,8 +334,8 @@ namespace CnGalWebSite.APIServer.Controllers
                         try
                         {
                             entry = await _entryRepository.GetAll()
-                                                       .Include(s => s.Information)
-                                                         .ThenInclude(s => s.Additional)
+                                                       .Include(s => s.Information).ThenInclude(s => s.Additional)
+                                                       .Include(s=>s.EntryRelationFromEntryNavigation).ThenInclude(s=>s.ToEntryNavigation)
                                                        .FirstOrDefaultAsync(s => s.Id == examine.EntryId);
                             if (entry == null)
                             {


### PR DESCRIPTION
添加了在编辑附加信息时跟踪关联词条的代码，但不确定能不能修复，观察一段时间