### PR TITLE
Update sponsors, media partners, and task link

### DIFF
--- a/CnGalWebSite/CnGalWebSite.Expo/Components/Cards/Home/SponsorsCard.razor
+++ b/CnGalWebSite/CnGalWebSite.Expo/Components/Cards/Home/SponsorsCard.razor
@@ -1,29 +1,25 @@
 ﻿<div class="home-sponsors-card">
+    @*
     <div class="sponsors-card">
         <div class="title-card">
             <span>赞助商</span>
         </div>
         <div class="items-card">
-            虚位以待
-           @*  <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
             <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
             <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-      *@   </div>
+            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
+        </div>
     </div>
+    *@
     <div class="media-partners-card">
         <div class="title-card">
-            <span>合作媒体</span>
+            <span>媒体协力</span>
         </div>
         <div class="items-card">
-            虚位以待 @* <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/5f61e77b8edc85350cf4ba00e20b7f55?https://image.cngal.org/images/upload/20241024/3e02fac028ecc73055466066ef7ea2a4eeea75b4.jpg" Name="CnGal鉴赏家" Url="https://www.cngal.org" />
-         *@</div>
+            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/772fdc00bb7e0af98b83802ceb3677bf?https://image.cngal.org/images/upload/20250727/139777d6d0f4539f7b0e20b2d3d4034f4106ed0c.png" Name="Galgame批评" Url="https://space.bilibili.com/2072586344" />
+            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/4bed36de6d02ec7d57b0d20b2951d3dd?https://image.cngal.org/images/2021/09/25/YM_cngal_link.png" Name="月幕Galgame" Url="https://www.ymgal.games" />
+            <ImageButtonCard Image="https://tucang.cngal.top/api/image/show/772fdc00bb7e0af98b83802ceb3677bf" Name="萌百视觉小说研究会" Url="https://space.bilibili.com/3461576839400339" />
+        </div>
     </div>
 </div>
 

--- a/CnGalWebSite/CnGalWebSite.Expo/Components/Cards/Lotteries/TasksCard.razor
+++ b/CnGalWebSite/CnGalWebSite.Expo/Components/Cards/Lotteries/TasksCard.razor
@@ -112,7 +112,7 @@
                 Name = "预约CnGal十周年庆直播",
                 Points = 50,
                 IsCompleted = Model.IsBooking,
-                Link = "https://space.bilibili.com/145239325",
+                Link = "https://space.bilibili.com/145239325/dynamic",
                 OnClick = OnClickBooking
             },
             new TaskItem


### PR DESCRIPTION
Updated the SponsorsCard to revise the display of sponsors and media partners, including new images, names, and URLs. Changed the media partners section title and added actual partners. In TasksCard, updated the booking task link to point to the correct Bilibili dynamic page.