### PR TITLE
Replace '联系我们' with 'Steam特卖页' in navigation

### DIFF
--- a/CnGalWebSite/CnGalWebSite.Expo/Components/Layout/MainLayout.razor
+++ b/CnGalWebSite/CnGalWebSite.Expo/Components/Layout/MainLayout.razor
@@ -18,7 +18,7 @@
                 <CnGalWebSite.Components.Buttons.MasaButton Color="white" TextStyle Icon="mdi-gift" Text="预约抽奖" Href="/lottery" />
                 <CnGalWebSite.Components.Buttons.MasaButton Color="white" TextStyle Icon="mdi-wallet-giftcard" Text="直播抽号" Href="/anniversary" />
                 <CnGalWebSite.Components.Buttons.MasaButton Color="white" TextStyle Icon="mdi-clipboard-text" Text="问卷调查" Href="/questionnaires" />
-                <CnGalWebSite.Components.Buttons.MasaButton Color="white" TextStyle Icon="mdi-email" Text="联系我们" Href="/contact" />
+                <CnGalWebSite.Components.Buttons.MasaButton Color="white" TextStyle Icon="mdi-steam" Text="Steam特卖页" Href="https://store.steampowered.com/curator/11627314-CnGal/sale/cngal2025" />
                 <CnGalWebSite.Expo.Components.Cards.Users.LoginButton />
             </div>
         </MAppBar>
@@ -32,7 +32,7 @@
                 <MTab Href="/lottery">预约抽奖</MTab>
                 <MTab Href="/anniversary">直播抽号</MTab>
                 <MTab Href="/questionnaires">问卷调查</MTab>
-                <MTab Href="/contact">联系我们</MTab>
+                <MTab Href="https://store.steampowered.com/curator/11627314-CnGal/sale/cngal2025">Steam特卖页</MTab>
             </MTabs>
         </MAppBar>
         <MNavigationDrawer @bind-Value="_drawer" App Right Temporary>
@@ -44,7 +44,7 @@
                 <CnGalWebSite.Components.Buttons.MasaButton TextStyle Icon="mdi-gift" Text="预约抽奖" Href="/lottery" OnClick="@(() => _drawer = false)" />
                 <CnGalWebSite.Components.Buttons.MasaButton TextStyle Icon="mdi-wallet-giftcard" Text="直播抽号" Href="/anniversary" OnClick="@(() => _drawer = false)" />
                 <CnGalWebSite.Components.Buttons.MasaButton TextStyle Icon="mdi-clipboard-text" Text="问卷调查" Href="/questionnaires" OnClick="@(() => _drawer = false)" />
-                <CnGalWebSite.Components.Buttons.MasaButton TextStyle Icon="mdi-email" Text="联系我们" Href="/contact" OnClick="@(() => _drawer = false)" />
+                <CnGalWebSite.Components.Buttons.MasaButton TextStyle Icon="mdi-steam" Text="Steam特卖页" Href="https://store.steampowered.com/curator/11627314-CnGal/sale/cngal2025" OnClick="@(() => _drawer = false)" />
             </div>
         </MNavigationDrawer>
     }


### PR DESCRIPTION
Updated navigation buttons and tabs in MainLayout.razor to link to the Steam sale page instead of the contact page, reflecting a change in site focus or promotion.