### PR TITLE
Add Umami analytics script

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite/Components/App.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite/Components/App.razor
@@ -52,6 +52,7 @@
     <link rel="stylesheet" href="@Assets["CnGalWebSite.MainSite.styles.css"]"/>
     <ImportMap/>
     <HeadOutlet/>
+    <script async src="https://umami.cngal.top/script.js" data-website-id="c190d5e2-f859-430c-8463-be388f6875b0"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Insert an async Umami analytics script tag into the <head> of App.razor to enable site usage tracking. The script is loaded from https://umami.cngal.top/script.js and uses the website ID c190d5e2-f859-430c-8463-be388f6875b0.