### PR TITLE
移除布局组件中的 StreamRendering 属性

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Layout/AdminLayout.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Layout/AdminLayout.razor
@@ -1,5 +1,4 @@
-@inherits LayoutComponentBase
-@attribute [StreamRendering]
+﻿@inherits LayoutComponentBase
 @inject NavigationManager NavigationManager
 
 <AuthorizeView Roles="Admin">

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Layout/MainLayout.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Layout/MainLayout.razor
@@ -1,5 +1,4 @@
 ﻿@inherits LayoutComponentBase
-@attribute [StreamRendering]
 @using CnGalWebSite.MainSite.Shared.Components.Layout
 @inject NavigationManager NavigationManager
 @inject IMainSiteAuthRequestService AuthRequestService


### PR DESCRIPTION
删除了 AdminLayout.razor 和 MainLayout.razor 文件中的 @attribute [StreamRendering]，并调整了 AdminLayout.razor 文件开头的代码格式。