### PR TITLE
优化看板初始定位及徽章样式调整

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Layout/UserMenu.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Layout/UserMenu.razor.css
@@ -11,7 +11,6 @@
     background-color: color-mix(in oklab, var(--cg-color-border) 40%, var(--cg-color-surface));
     color: var(--cg-color-text-muted);
     border: none;
-    overflow: hidden;
     cursor: pointer;
     transition: background-color var(--cg-transition-fast), color var(--cg-transition-fast);
 }
@@ -217,9 +216,9 @@
     position: absolute;
     top: -2px;
     right: -2px;
-    min-width: 16px;
-    height: 16px;
+    min-width: 20px;
     padding: 0 4px;
+    aspect-ratio: 1;
     font-size: 10px;
     font-weight: var(--cg-font-weight-bold);
     line-height: 16px;
@@ -230,6 +229,7 @@
     border: 2px solid var(--cg-color-surface);
     pointer-events: none;
     z-index: 1;
+    align-content: center;
 }
 
 /* make trigger button a positioning context */

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Message/MessagePage.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Message/MessagePage.razor.css
@@ -1,4 +1,4 @@
-/* ── MessagePage ── */
+﻿/* ── MessagePage ── */
 
 .message-page {
     max-width: 1200px;
@@ -33,7 +33,7 @@
 /* ── Tab panel ── */
 
 .message-page__tab-panel {
-    padding-top: var(--cg-spacing-4);
+
 }
 
 /* ── Loading ── */

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Services/KanbanSettingService.cs
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Services/KanbanSettingService.cs
@@ -90,6 +90,13 @@ public class KanbanSettingService : IKanbanSettingService
             {
                 _kanban.ApplyMobileDefaults();
             }
+
+            // 动态计算右下角初始位置
+            // 右侧与底部留出与浮动工具栏一致的间距：桌面端 32px，移动端 16px + 底部导航栏高度
+            var rightGap = size.Width < 768 ? 16 : 32;
+            var bottomGap = size.Width < 768 ? 72 : 32;
+            _kanban.Position.Left = Math.Max(0, size.Width - _kanban.Size.Width - rightGap);
+            _kanban.Position.Top = Math.Max(0, size.Height - _kanban.Size.Height - bottomGap);
         }
         catch
         {


### PR DESCRIPTION
- Kanban 初始化时根据窗口尺寸动态设置右下角位置，提升桌面端与移动端适配性
- 调整 .cg-badge 样式，增大最小宽度，移除固定高度，增加 aspect-ratio，优化内容居中
- 移除 .cg-action-btn 的 overflow: hidden
- 移除 MessagePage tab panel 顶部内边距