### PR TITLE
修复 EntryCardList ShowExpandButton 属性绑定问题

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Entry/EntryDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Entry/EntryDetailPage.razor
@@ -526,7 +526,7 @@ else
         {
             var displayTitle = items.Count > 4 ? $"{title} ({items.Count})" : title;
             <EntrySection Title="@displayTitle" Icon="@icon" Show="true">
-                <EntryCardList LimitCount="@limitCount" ShowExpandButton="items.Count > @limitCount">
+                <EntryCardList LimitCount="@limitCount" ShowExpandButton="@(items.Count > limitCount)">
                     @foreach (var item in items)
                     {
                         <li>


### PR DESCRIPTION
修正了 EntryDetailPage.razor 中 ShowExpandButton 的绑定方式，确保条件表达式能被正确解析并传递布尔值，避免因语法问题导致的显示异常。