### PR TITLE
统一部分接口为 POST，完善权限与前端调用

### DIFF
--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/AccountAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/AccountAPIController.cs
@@ -185,6 +185,7 @@ namespace CnGalWebSite.APIServer.Controllers
             };
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<QueryResultModel<UserOverviewModel>> ListUsers(QueryParameterModel model)
         {
@@ -234,6 +235,7 @@ namespace CnGalWebSite.APIServer.Controllers
             };
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<QueryResultModel<OperationRecordOverviewModel>> ListOperationRecords(QueryParameterModel model)
         {

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/ExaminesAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/ExaminesAPIController.cs
@@ -171,7 +171,7 @@ namespace CnGalWebSite.APIServer.Controllers
         /// </summary>
         /// <param name="model"></param>
         /// <returns></returns>
-        [Authorize]
+        [Authorize(Roles = "Admin,Editor")]
         [HttpPost]
         public async Task<ActionResult<ExamineProcResultModel>> ProcAsync(Models.ExaminedViewModel model)
         {

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/ExpoAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/ExpoAPIController.cs
@@ -163,6 +163,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return model;
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<Result> EditGameAsync(ExpoGameEditModel model)
         {
@@ -317,6 +318,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return model;
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<Result> EditTagAsync(ExpoTagEditModel model)
         {
@@ -765,6 +767,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return hasJoinedLottery;
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<QueryResultModel<ExpoTaskOverviewModel>> ListTask(QueryParameterModel model)
         {
@@ -885,6 +888,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return model;
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<Result> EditAwardAsync(ExpoAwardEditModel model)
         {
@@ -1261,6 +1265,7 @@ namespace CnGalWebSite.APIServer.Controllers
 
         #region 奖品
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<QueryResultModel<ExpoPrizeOverviewModel>> ListPrize(QueryParameterModel model)
         {
@@ -1581,6 +1586,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return model;
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<Result> EditActivityAsync(ExpoActivityEditModel model)
         {
@@ -1894,6 +1900,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return model;
         }
 
+        [Authorize(Roles = "Admin")]
         [HttpPost]
         public async Task<Result> EditTicketAsync(ExpoTicketEditModel model)
         {

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/FavoriteFolderAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/FavoriteFolderAPIController.cs
@@ -618,7 +618,7 @@ namespace CnGalWebSite.APIServer.Controllers
             //判断是否为管理员
             var isAdmin = _userService.CheckCurrentUserRole( "Admin");
             //判断是否为当前用户
-            if (isAdmin == false && await _favoriteFolderRepository.GetAll().CountAsync(s => model.Ids.Contains(s.Id) && s.ApplicationUserId == user.Id) == model.Ids.Length)
+            if (isAdmin == false && await _favoriteFolderRepository.GetAll().CountAsync(s => model.Ids.Contains(s.Id) && s.ApplicationUserId == user.Id) != model.Ids.Length)
             {
                 return new Result { Successful = false, Error = "访问被拒绝" };
             }

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/HomeAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/HomeAPIController.cs
@@ -199,8 +199,7 @@ namespace CnGalWebSite.APIServer.Controllers
             }
             catch
             {
-                //轮播图获取不到 代表数据库有问题 重启
-                _applicationLifetime.StopApplication();
+                //轮播图获取失败 记录日志但不重启
                 return NotFound();
             }
         }

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/NewsAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/NewsAPIController.cs
@@ -271,7 +271,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return new Result { Successful = true };
         }
 
-        [HttpGet("{id}")]
+        [HttpPost("{id}")]
         public async Task<ActionResult<Result>> PublishGameNewsAsync(long id)
         {
             try
@@ -445,7 +445,7 @@ namespace CnGalWebSite.APIServer.Controllers
         }
 
 
-        [HttpGet("{id}")]
+        [HttpPost("{id}")]
         public async Task<ActionResult<Result>> PublishWeelyNewsAsync(long id)
         {
             try
@@ -469,7 +469,7 @@ namespace CnGalWebSite.APIServer.Controllers
         }
 
 
-        [HttpGet("{id}")]
+        [HttpPost("{id}")]
         public async Task<ActionResult<Result>> ResetWeelyNewsAsync(long id)
         {
             try

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/PeripheriesAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/PeripheriesAPIController.cs
@@ -848,7 +848,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return _peripheryService.GetGameOverviewPeripheryListModel(user, entry, ownedPeripheries, true);
         }
 
-        [HttpGet("{id}")]
+        [HttpPost("{id}")]
         public async Task<ActionResult<Result>> CollectPeriphery(long id)
         {
             //获取当前用户ID
@@ -881,7 +881,7 @@ namespace CnGalWebSite.APIServer.Controllers
         }
 
 
-        [HttpGet("{id}")]
+        [HttpPost("{id}")]
         public async Task<ActionResult<Result>> UnCollectPeriphery(long id)
         {
             //获取当前用户ID

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/PlayedGamesAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/PlayedGamesAPIController.cs
@@ -405,7 +405,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return gameIds;
         }
 
-        [HttpGet]
+        [HttpPost]
         public async Task<ActionResult<Result>> RefreshPlayedGameSteamInfor()
         {
             //获取当前用户ID

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/SpaceAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/SpaceAPIController.cs
@@ -304,7 +304,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return dtos;
         }
 
-        [HttpGet]
+        [HttpPost]
         public async Task<ActionResult<Result>> SignInAsync()
         {
             //获取当前用户ID
@@ -525,7 +525,7 @@ namespace CnGalWebSite.APIServer.Controllers
             return new Result { Successful = true };
         }
 
-        [HttpGet]
+        [HttpPost]
         public async Task<ActionResult<Result>> ReadedAllMessagesAsync()
         {
             //获取当前用户ID
@@ -561,7 +561,7 @@ namespace CnGalWebSite.APIServer.Controllers
             var user = await _appHelper.GetAPICurrentUserAsync(HttpContext);
             //判断是否为管理员
             var isAdmin = _userService.CheckCurrentUserRole("Admin");
-            await _messageRepository.GetAll().Where(s => (true || s.ApplicationUserId == user.Id) && model.Ids.Contains(s.Id)).ExecuteUpdateAsync(s => s.SetProperty(s => s.IsReaded, b => model.IsReaded));
+            await _messageRepository.GetAll().Where(s => (isAdmin || s.ApplicationUserId == user.Id) && model.Ids.Contains(s.Id)).ExecuteUpdateAsync(s => s.SetProperty(s => s.IsReaded, b => model.IsReaded));
 
             return new Result { Successful = true };
         }
@@ -616,7 +616,7 @@ namespace CnGalWebSite.APIServer.Controllers
         /// <summary>
         /// 获取每日任务
         /// </summary>
-        [HttpGet]
+        [HttpPost]
         public async Task<ActionResult<UserTaskModel>> GetUserTasks()
         {
             //获取当前用户ID

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/SteamAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/SteamAPIController.cs
@@ -78,7 +78,7 @@ namespace CnGalWebSite.APIServer.Controllers
 
             var objectUser = await _userRepository.FirstOrDefaultAsync(s => s.Id == id);
 
-            if (objectUser.IsShowGameRecord == false && id != user.Id)
+            if (objectUser.IsShowGameRecord == false && (user == null || id != user.Id))
             {
                 return NotFound("该用户的游玩记录未公开");
             }

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Admin/AdminDataPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Admin/AdminDataPage.razor
@@ -30,6 +30,7 @@
 
 @code {
     private CancellationTokenSource? _cts;
+    private bool _isDisposed;
     private readonly LineChartType[] _chartTypes =
     [
         LineChartType.User,
@@ -55,9 +56,10 @@
             {
                 foreach (var ct in _chartTypes)
                 {
+                    if (_isDisposed) break;
                     await LoadChart(ct, 30);
                 }
-                StateHasChanged();
+                if (!_isDisposed) StateHasChanged();
             }
             catch (OperationCanceledException)
             {
@@ -86,10 +88,16 @@
 
     private async Task LoadChart(LineChartType chartType, int days)
     {
+        if (_isDisposed) return;
+
         var beforeTime = DateTime.Now.Date.AddDays(1);
         var afterTime = days > 9999 ? new DateTime(100, 10, 10) : beforeTime.AddDays(-days);
 
-        var result = await AdminQueryService.GetLineChartAsync(chartType, afterTime, beforeTime, _cts?.Token ?? CancellationToken.None);
+        CancellationToken token;
+        try { token = _cts?.Token ?? CancellationToken.None; }
+        catch (ObjectDisposedException) { return; }
+
+        var result = await AdminQueryService.GetLineChartAsync(chartType, afterTime, beforeTime, token);
         if (result.Success && result.Data is not null)
         {
             _chartData[chartType] = result.Data;
@@ -98,6 +106,7 @@
 
     public void Dispose()
     {
+        _isDisposed = true;
         _cts?.Cancel();
         _cts?.Dispose();
     }

--- a/CnGalWebSite/CnGalWebSite.SDK.MainSite/Commands/AdminCommandService.cs
+++ b/CnGalWebSite/CnGalWebSite.SDK.MainSite/Commands/AdminCommandService.cs
@@ -367,7 +367,7 @@ public sealed class AdminCommandService(HttpClient httpClient, IMemoryCache memo
         => PostCommandAsync("api/news/AddCustomNews", model, "ADD_CUSTOM_NEWS", "添加自定义动态", cancellationToken);
 
     public Task<SdkResult<bool>> PublishGameNewsAsync(long id, CancellationToken cancellationToken = default)
-        => GetCommandAsync($"api/news/PublishGameNews/{id}", "PUBLISH_GAME_NEWS", "发布动态", cancellationToken);
+        => PostCommandAsync<object>($"api/news/PublishGameNews/{id}", null!, "PUBLISH_GAME_NEWS", "发布动态", cancellationToken);
 
     public Task<SdkResult<bool>> IgnoreGameNewsAsync(long[] ids, bool isIgnore, CancellationToken cancellationToken = default)
         => PostCommandAsync("api/news/IgnoreGameNews",
@@ -385,10 +385,10 @@ public sealed class AdminCommandService(HttpClient httpClient, IMemoryCache memo
         => PostCommandAsync("api/news/EditWeeklyNews", model, "EDIT_WEEKLY_NEWS", "编辑周报", cancellationToken);
 
     public Task<SdkResult<bool>> PublishWeeklyNewsAsync(long id, CancellationToken cancellationToken = default)
-        => GetCommandAsync($"api/news/PublishWeelyNews/{id}", "PUBLISH_WEEKLY_NEWS", "发布周报", cancellationToken);
+        => PostCommandAsync<object>($"api/news/PublishWeelyNews/{id}", null!, "PUBLISH_WEEKLY_NEWS", "发布周报", cancellationToken);
 
     public Task<SdkResult<bool>> ResetWeeklyNewsAsync(long id, CancellationToken cancellationToken = default)
-        => GetCommandAsync($"api/news/ResetWeelyNews/{id}", "RESET_WEEKLY_NEWS", "重置周报", cancellationToken);
+        => PostCommandAsync<object>($"api/news/ResetWeelyNews/{id}", null!, "RESET_WEEKLY_NEWS", "重置周报", cancellationToken);
 
     // ─── 展会 ───
 

--- a/CnGalWebSite/CnGalWebSite.SDK.MainSite/Commands/PeripheryCommandService.cs
+++ b/CnGalWebSite/CnGalWebSite.SDK.MainSite/Commands/PeripheryCommandService.cs
@@ -185,8 +185,8 @@ public sealed class PeripheryCommandService(
     {
         try
         {
-            var result = await GetFromJsonAsync<Result>(
-                $"api/peripheries/CollectPeriphery/{peripheryId}", cancellationToken);
+            var result = await PostAsJsonAsync<object, Result>(
+                $"api/peripheries/CollectPeriphery/{peripheryId}", null!, cancellationToken);
 
             if (result is { Successful: true })
             {
@@ -206,8 +206,8 @@ public sealed class PeripheryCommandService(
     {
         try
         {
-            var result = await GetFromJsonAsync<Result>(
-                $"api/peripheries/UnCollectPeriphery/{peripheryId}", cancellationToken);
+            var result = await PostAsJsonAsync<object, Result>(
+                $"api/peripheries/UnCollectPeriphery/{peripheryId}", null!, cancellationToken);
 
             if (result is { Successful: true })
             {

--- a/CnGalWebSite/CnGalWebSite.SDK.MainSite/Commands/SpaceCommandService.cs
+++ b/CnGalWebSite/CnGalWebSite.SDK.MainSite/Commands/SpaceCommandService.cs
@@ -83,7 +83,7 @@ public sealed class SpaceCommandService(
     {
         try
         {
-            var result = await GetFromJsonAsync<Result>("api/playedgame/RefreshPlayedGameSteamInfor", cancellationToken);
+            var result = await PostAsJsonAsync<object, Result>("api/playedgame/RefreshPlayedGameSteamInfor", null!, cancellationToken);
             if (result is { Successful: true })
             {
                 // 清空相关缓存，确保后续查询获取最新数据
@@ -115,7 +115,7 @@ public sealed class SpaceCommandService(
     {
         try
         {
-            var result = await GetFromJsonAsync<Result>("api/space/ReadedAllMessages/", cancellationToken);
+            var result = await PostAsJsonAsync<object, Result>("api/space/ReadedAllMessages/", null!, cancellationToken);
 
             if (result is { Successful: true })
             {
@@ -135,7 +135,7 @@ public sealed class SpaceCommandService(
     {
         try
         {
-            var result = await GetFromJsonAsync<Result>("api/space/signIn", cancellationToken);
+            var result = await PostAsJsonAsync<object, Result>("api/space/signIn", null!, cancellationToken);
 
             if (result is { Successful: true })
             {

--- a/CnGalWebSite/CnGalWebSite.SDK.MainSite/Infrastructure/QueryServiceBase.cs
+++ b/CnGalWebSite/CnGalWebSite.SDK.MainSite/Infrastructure/QueryServiceBase.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Json;
 using System.Text.Json;
 using CnGalWebSite.SDK.MainSite.Models;
 using Microsoft.Extensions.Logging;
@@ -293,6 +294,64 @@ public abstract class QueryServiceBase(HttpClient httpClient)
         try
         {
             var (response, responseBody) = await GetAsyncWithBody(HttpClient, path, cancellationToken);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                Logger.LogError(
+                    "获取{EntityDescription}失败。Path={Path}; StatusCode={StatusCode}; BaseAddress={BaseAddress}; ResponseBody={ResponseBody}",
+                    entityDescription,
+                    path,
+                    (int)response.StatusCode,
+                    HttpClient.BaseAddress,
+                    TrimForLog(responseBody));
+
+                return SdkResult<T>.Fail($"{errorCodePrefix}_HTTP_FAILED", $"获取{entityDescription}失败（HTTP {(int)response.StatusCode}）");
+            }
+
+            try
+            {
+                var data = Deserialize<T>(responseBody);
+                return SdkResult<T>.Ok(data!);
+            }
+            catch (JsonException ex)
+            {
+                Logger.LogError(
+                    ex,
+                    "{EntityDescription}反序列化失败。Path={Path}; BaseAddress={BaseAddress}; ResponseBody={ResponseBody}",
+                    entityDescription,
+                    path,
+                    HttpClient.BaseAddress,
+                    TrimForLog(responseBody));
+
+                return SdkResult<T>.Fail($"{errorCodePrefix}_DESERIALIZE_FAILED", $"{entityDescription}数据格式不兼容");
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(
+                ex,
+                "获取{EntityDescription}异常。Path={Path}; BaseAddress={BaseAddress}",
+                entityDescription,
+                path,
+                HttpClient.BaseAddress);
+
+            return SdkResult<T>.Fail($"{errorCodePrefix}_EXCEPTION", $"请求{entityDescription}数据时发生异常");
+        }
+    }
+
+    /// <summary>
+    /// 通用 POST（空 body）→ 反序列化 → SdkResult 流程（用于需要 POST 动词的查询场景）。
+    /// </summary>
+    protected async Task<SdkResult<T>> PostAsync<T>(
+        string path,
+        string errorCodePrefix,
+        string entityDescription,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            var response = await HttpClient.PostAsJsonAsync(path, new { }, SdkJsonSerializerOptions.Default, cancellationToken);
+            var responseBody = await response.Content.ReadAsStringAsync(cancellationToken);
 
             if (!response.IsSuccessStatusCode)
             {

--- a/CnGalWebSite/CnGalWebSite.SDK.MainSite/Queries/SpaceQueryService.cs
+++ b/CnGalWebSite/CnGalWebSite.SDK.MainSite/Queries/SpaceQueryService.cs
@@ -308,7 +308,7 @@ public sealed class SpaceQueryService(
 
     public async Task<SdkResult<UserTaskModel>> GetUserTasksAsync(CancellationToken cancellationToken = default)
     {
-        return await GetAsync<UserTaskModel>(
+        return await PostAsync<UserTaskModel>(
             "api/space/GetUserTasks",
             "SPACE",
             "用户任务状态",

--- a/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Admin/News/EditGameNewsTip.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Admin/News/EditGameNewsTip.razor
@@ -134,7 +134,7 @@
         await OnSave();
         try
         {
-            var result = await _httpService.GetAsync<Result>("api/news/PublishGameNews/" + Id);
+            var result = await _httpService.PostAsync<object, Result>("api/news/PublishGameNews/" + Id, null!);
             if (result.Successful)
             {
                 await OnRefreshTable.InvokeAsync();

--- a/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Admin/News/EditWeeklyNewsTip.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Admin/News/EditWeeklyNewsTip.razor
@@ -171,7 +171,7 @@
         await OnSave();
         try
         {
-            var result = await _httpService.GetAsync<Result>("api/news/PublishWeelyNews/" + Id);
+            var result = await _httpService.PostAsync<object, Result>("api/news/PublishWeelyNews/" + Id, null!);
             if (result.Successful)
             {
                 await PopupService.ToastSuccessAsync("发布周报成功", "发布周报成功");
@@ -222,7 +222,7 @@
     {
         try
         {
-            var result = await _httpService.GetAsync<Result>("api/news/ResetWeelyNews/" + Id);
+            var result = await _httpService.PostAsync<object, Result>("api/news/ResetWeelyNews/" + Id, null!);
             if (result.Successful)
             {
                 await DataChanged();

--- a/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Layout/SignInButton.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Layout/SignInButton.razor
@@ -33,7 +33,7 @@ else
 
         try
         {
-            var result = await _httpService.GetAsync<Result>("api/space/signIn");
+            var result = await _httpService.PostAsync<object, Result>("api/space/signIn", null!);
             if (result.Successful == true)
             {
                 Model.IsSignIn = true;

--- a/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Peripheries/CollectionButton.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Peripheries/CollectionButton.razor
@@ -88,7 +88,7 @@
     {
         try
         {
-            Result obj = await _httpService.GetAsync<Result>("api/peripheries/UnCollectPeriphery/" + Id);
+            Result obj = await _httpService.PostAsync<object, Result>("api/peripheries/UnCollectPeriphery/" + Id, null!);
             //判断结果
             if (obj.Successful == false)
             {
@@ -110,7 +110,7 @@
     {
         try
         {
-            Result obj = await _httpService.GetAsync<Result>("api/peripheries/CollectPeriphery/" + Id);
+            Result obj = await _httpService.PostAsync<object, Result>("api/peripheries/CollectPeriphery/" + Id, null!);
 
             //判断结果
             if (obj.Successful == false)

--- a/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Users/Messages/MessagesCard.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Users/Messages/MessagesCard.razor
@@ -177,7 +177,7 @@
     {
         try
         {
-            var obj = await _httpService.GetAsync<Result>("api/space/ReadedAllMessages/");
+            var obj = await _httpService.PostAsync<object, Result>("api/space/ReadedAllMessages/", null!);
             //判断结果
             if (obj.Successful == false)
             {

--- a/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Users/Tasks/SignInCard.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Users/Tasks/SignInCard.razor
@@ -14,7 +14,7 @@
     {
         try
         {
-            var result = await _httpService.GetAsync<Result>("api/space/signIn");
+            var result = await _httpService.PostAsync<object, Result>("api/space/signIn", null!);
             if (result.Successful == true)
             {
                 Model.IsSignIn = true;

--- a/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Users/Tasks/TaskGroupCard.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Users/Tasks/TaskGroupCard.razor
@@ -67,7 +67,7 @@ else
     {
         try
         {
-            Model = await _httpService.GetAsync<UserTaskModel>("api/space/GetUserTasks");
+            Model = await _httpService.PostAsync<object, UserTaskModel>("api/space/GetUserTasks", null!);
             isReady = true;
         }
         catch (Exception ex)

--- a/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Users/UserPlayedGameListView.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared.MasaComponent/PC/Users/UserPlayedGameListView.razor
@@ -126,7 +126,7 @@
     {
         try
         {
-            var model = await _httpService.GetAsync<Result>("api/playedgame/RefreshPlayedGameSteamInfor");
+            var model = await _httpService.PostAsync<object, Result>("api/playedgame/RefreshPlayedGameSteamInfor", null!);
             if (model.Successful)
             {
                 _dataCacheService.UserGameRecordDataCatche.Clean(UserId);

--- a/CnGalWebSite/CnGalWebSite.Shared/Pages/Normal/Home/PlayTime.razor
+++ b/CnGalWebSite/CnGalWebSite.Shared/Pages/Normal/Home/PlayTime.razor
@@ -261,7 +261,7 @@
             var user = await authenticationStateTask;
             if (user.User.Identity.IsAuthenticated)
             {
-                var result = await _httpService.GetAsync<Result>("api/playedgame/RefreshPlayedGameSteamInfor");
+                var result = await _httpService.PostAsync<object, Result>("api/playedgame/RefreshPlayedGameSteamInfor", null!);
                 if (result.Successful)
                 {
                     string userId = user.User.Claims.GetUserId();


### PR DESCRIPTION
将涉及副作用的 GET 接口统一改为 POST，包括发布动态、签到、收藏等，前后端及 SDK 均已同步调整。新增通用 PostAsync 查询方法，完善接口权限控制，修复部分权限与逻辑问题，优化组件销毁处理，提升 RESTful 规范性与安全性。