### PR TITLE
优化抽奖卡片图片加载与宽高比适配

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Lottery/Home/LotteryCardItem.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Lottery/Home/LotteryCardItem.razor
@@ -3,10 +3,16 @@
 
 <li>
     <div class="lottery-card">
-        @if (!string.IsNullOrWhiteSpace(Model.Thumbnail))
+        @if (!string.IsNullOrWhiteSpace(Model.MainPicture) || !string.IsNullOrWhiteSpace(Model.Thumbnail))
         {
             <a class="lottery-card-image-wrapper" href="@($"/lotteries/index/{Model.Id}")">
-                <img src="@Model.Thumbnail" alt="@Model.Name" class="lottery-card-image" loading="lazy" />
+                <picture>
+                    @if (!string.IsNullOrWhiteSpace(Model.Thumbnail))
+                    {
+                        <source media="(min-width: 768px)" srcset="@Model.Thumbnail">
+                    }
+                    <img src="@(Model.MainPicture ?? Model.Thumbnail)" alt="@Model.Name" class="lottery-card-image" loading="lazy" />
+                </picture>
             </a>
         }
         <div class="lottery-card-body">

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Lottery/Home/LotteryCardItem.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Lottery/Home/LotteryCardItem.razor.css
@@ -23,7 +23,7 @@
 .lottery-card-image-wrapper {
     position: relative;
     width: 100%;
-    aspect-ratio: 16 / 9;
+    aspect-ratio: 460 / 215;
     overflow: hidden;
     background: color-mix(in oklab, var(--cg-color-bg) 90%, white);
     flex-shrink: 0;


### PR DESCRIPTION
优化 LotteryCardItem.razor 图片加载逻辑，使用 picture 标签支持响应式加载缩略图和主图。调整 .lottery-card-image-wrapper 的宽高比为 460:215，更好适配图片展示需求。