### PR TITLE
统一管理并动态更新页面 SEO meta 信息

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/DesignSystem/CgPageMeta.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/DesignSystem/CgPageMeta.razor
@@ -1,4 +1,8 @@
-@* 统一页面标题与 SEO meta 标签，对齐旧站 TitleTip 组件行为 *@
+@* 统一页面标题与 SEO meta 标签，对齐旧站 TitleTip 组件行为
+   实现方式：通过 IPageMetaService 将 meta 值写入 scoped 服务，
+   App.razor 在渲染 <head> 时直接读取，绕过 HeadContent/HeadOutlet 时序问题 *@
+@using CnGalWebSite.MainSite.Shared.Services
+@inject IPageMetaService PageMetaService
 
 <PageTitle>@ComputedTitle</PageTitle>
 <HeadContent>
@@ -38,4 +42,11 @@
 
     private string ComputedImage =>
         string.IsNullOrWhiteSpace(Image) ? DefaultImage : Image;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+        // 将 meta 值写入 scoped 服务（值变更时自动通知 App.razor 刷新 <head>）
+        PageMetaService.SetMeta(Title, Description, Image);
+    }
 }

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Extensions/ServiceCollectionExtensions.cs
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ServiceCollectionExtensions
         services.AddScoped<ICgDeviceIdentificationService, CgDeviceIdentificationService>();
         services.AddScoped<IMiniModeService, MiniModeService>();
         services.AddScoped<ICgThemeService, CgThemeService>();
+        services.AddScoped<IPageMetaService, PageMetaService>();
         services.AddScoped<IKanbanSettingService, KanbanSettingService>();
         services.AddScoped<IKanbanUserDataService, KanbanUserDataService>();
         services.AddScoped<IKanbanEventService, KanbanEventService>();

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Entry/BirthdayCalendarPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Entry/BirthdayCalendarPage.razor
@@ -4,7 +4,7 @@
 @implements IDisposable
 @using CnGalWebSite.MainSite.Shared.Components.Features.Entry.Detail
 
-<CgPageMeta Title="角色生日日历" />
+<CgPageMeta Title="角色生日日历" Description="可以在这里按月份查看所有角色的生日" />
 
 @if (_errorMessage is not null)
 {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/CVThematicPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/CVThematicPage.razor
@@ -10,7 +10,7 @@
 @using CnGalWebSite.MainSite.Shared.Components.Features.Home
 @using static CnGalWebSite.MainSite.Shared.Components.DesignSystem.CgCarousel
 
-<CgPageMeta Title="专题页 - CV" />
+<CgPageMeta Title="专题页 - CV" Description="聚合有关配音演员的信息" />
 
 <div class="cv-page">
     @if (IsLoading)

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/RevenuePage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/RevenuePage.razor
@@ -7,7 +7,7 @@
 @using CnGalWebSite.DataModel.ViewModel.Stores
 @using CnGalWebSite.MainSite.Shared.Components.Features.Home
 
-<CgPageMeta Title="国G销量年榜" />
+<CgPageMeta Title="国G销量年榜" Description="榜单仅收录当年新发售，且在CnGal资料站中收录的作品" />
 
 <div class="revenue-page">
     <div class="revenue-page__header">

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/ShareGamesPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/ShareGamesPage.razor
@@ -5,7 +5,7 @@
 @inject IPlayedGameQueryService PlayedGameQueryService
 @implements IDisposable
 
-<CgPageMeta Title="分享游戏库" />
+<CgPageMeta Title="分享游戏库" Description="展示你的游戏收藏和游玩时长" />
 
 @if (_errorMessage is not null)
 {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/SquarePage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/SquarePage.razor
@@ -4,7 +4,7 @@
 @using CnGalWebSite.MainSite.Shared.Components.Features.Home
 
 
-<CgPageMeta Title="广场" />
+<CgPageMeta Title="广场" Description="查看编辑概览、抽奖、投票、随机展示、数据汇总等众多内容" />
 
 @if (ErrorMessage is not null)
 {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Lottery/LotteryHomePage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Lottery/LotteryHomePage.razor
@@ -4,7 +4,7 @@
 @implements IDisposable
 @using CnGalWebSite.MainSite.Shared.Components.Features.Lottery.Home
 
-<CgPageMeta Title="抽奖板块" />
+<CgPageMeta Title="抽奖板块" Description="快来参加抽奖吧" />
 
 @if (_errorMessage is not null)
 {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Services/IPageMetaService.cs
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Services/IPageMetaService.cs
@@ -1,0 +1,50 @@
+namespace CnGalWebSite.MainSite.Shared.Services;
+
+/// <summary>
+/// 页面级 SEO meta 状态传递服务（Scoped）。
+/// CgPageMeta 组件在 OnParametersSet 中将值写入此服务。
+/// App.razor 渲染 &lt;head&gt; 时直接读取并渲染 &lt;meta&gt; 标签。
+/// SetMeta 仅在值发生变更时自动通知订阅者重新渲染。
+/// </summary>
+public interface IPageMetaService
+{
+    string Title { get; }
+    string Description { get; }
+    string Image { get; }
+    event Action? OnChanged;
+
+    /// <summary>设置页面 meta 信息，值变更时自动触发 OnChanged。</summary>
+    void SetMeta(string? title, string? description, string? image);
+}
+
+public sealed class PageMetaService : IPageMetaService
+{
+    private const string DefaultTitle = "CnGal 中文GalGame资料站";
+    private const string DefaultDescription = "CnGal资料站的建站目的是收集，索引国产gal及中文化galgame资料、文章、攻略，为galgame同好们提供方便。";
+    private const string DefaultImage = "https://app.cngal.org/_content/CnGalWebSite.Shared/images/logo.png";
+
+    private string _title = DefaultTitle;
+    private string _description = DefaultDescription;
+    private string _image = DefaultImage;
+
+    public string Title => _title;
+    public string Description => _description;
+    public string Image => _image;
+
+    public event Action? OnChanged;
+
+    public void SetMeta(string? title, string? description, string? image)
+    {
+        var newTitle = string.IsNullOrWhiteSpace(title) ? DefaultTitle : $"{title} - {DefaultTitle}";
+        var newDescription = string.IsNullOrWhiteSpace(description) ? DefaultDescription : description;
+        var newImage = string.IsNullOrWhiteSpace(image) ? DefaultImage : image;
+
+        if (_title != newTitle || _description != newDescription || _image != newImage)
+        {
+            _title = newTitle;
+            _description = newDescription;
+            _image = newImage;
+            OnChanged?.Invoke();
+        }
+    }
+}

--- a/CnGalWebSite/CnGalWebSite.MainSite/Components/App.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite/Components/App.razor
@@ -1,6 +1,8 @@
 ﻿@using CnGalWebSite.MainSite.Shared.Services
 @using Microsoft.AspNetCore.Http
 @inject IHttpContextAccessor HttpContextAccessor
+@inject IPageMetaService PageMetaService
+@implements IDisposable
 
 <!DOCTYPE html>
 <html lang="zh-CN" data-theme="@InitialTheme">
@@ -51,6 +53,9 @@
     <link rel="stylesheet" href="@Assets["_content/CnGalWebSite.MainSite.Shared/styles/design-tokens.css"]"/>
     <link rel="stylesheet" href="@Assets["CnGalWebSite.MainSite.styles.css"]"/>
     <ImportMap/>
+    <meta name="description" content="@PageMetaService.Description">
+    <meta itemprop="name" content="@PageMetaService.Title" />
+    <meta itemprop="image" content="@PageMetaService.Image" />
     <HeadOutlet/>
     <script async src="https://umami.cngal.top/script.js" data-website-id="c190d5e2-f859-430c-8463-be388f6875b0"></script>
     <script type="text/javascript">
@@ -156,5 +161,22 @@
             var theme = HttpContextAccessor.HttpContext?.Request.Cookies[ThemeConstants.CookieName];
             return theme is ThemeConstants.DarkValue or ThemeConstants.LightValue ? theme : null;
         }
+    }
+
+    protected override void OnInitialized()
+    {
+        // 订阅 meta 变更事件，当子组件异步加载数据后更新 meta 值时触发重新渲染
+        PageMetaService.OnChanged += HandleMetaChanged;
+    }
+
+    private void HandleMetaChanged()
+    {
+        // 在 SSR 中，子组件数据加载完成后触发 App.razor 重渲染 <head> 内的 meta 标签
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        PageMetaService.OnChanged -= HandleMetaChanged;
     }
 }


### PR DESCRIPTION
引入 IPageMetaService 及实现，支持在 Blazor 组件间以 Scoped 服务同步页面标题、描述、图片等 meta 信息。CgPageMeta 组件参数变更时写入服务，App.razor 监听并动态渲染 <head> meta 标签，解决 HeadContent/HeadOutlet 时序问题，提升 SSR 兼容性和 SEO 效果。补充多页面 Description 字段，服务已注册至依赖注入。