### PR TITLE
Display all entry audio tracks (remove MaxCount)

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Entry/Detail/EntryAudioList.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Entry/Detail/EntryAudioList.razor
@@ -16,7 +16,7 @@
         </div>
         
         <div class="cg-audio-tracks">
-            @for (var i = 0; i < Audio.Take(MaxCount).Count(); i++)
+            @for (var i = 0; i < Audio.Count; i++)
             {
                 var item = Audio[i];
                 var index = i + 1;
@@ -64,5 +64,4 @@
 
 @code {
     [Parameter] public IReadOnlyList<EditAudioAloneModel> Audio { get; set; } = [];
-    [Parameter] public int MaxCount { get; set; } = 6;
 }

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Entry/EntryDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Entry/EntryDetailPage.razor
@@ -58,7 +58,7 @@ else if (Model is not null)
             <div class="entry-main-col">
                 <div class="entry-cell entry-cell--audio">
                     <EntryCard Title="音频" Icon="mdiMusicCircleOutline" Show="Model.Audio.Count > 0">
-                        <EntryAudioList Audio="Model.Audio" MaxCount="6" />
+                        <EntryAudioList Audio="Model.Audio" />
                     </EntryCard>
                 </div>
 


### PR DESCRIPTION
Render the full Audio list instead of limiting by MaxCount. The loop in EntryAudioList now iterates over Audio.Count, the MaxCount parameter/default was removed, and EntryDetailPage no longer passes MaxCount. This makes the audio section show all tracks rather than truncating to six.