### PR TITLE
Expo 页面新增带外链的横幅图片区域

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoAnniversaryPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoAnniversaryPage.razor
@@ -6,6 +6,11 @@
 <CgPageMeta Title="CNGAL周年庆展示会 - 直播抽号" />
 
 <div class="expo-anniversary-page">
+    <div class="banner-image">
+        <a href="https://space.bilibili.com/145239325/dynamic" target="_blank">
+            <img src="https://image.cngal.org/images/upload/20260719/5dadcb55f02d86dce9548e68a907226ddeab3417.jpg" alt="展会横幅" />
+        </a>
+    </div>
     <CgTabs Variant="underline"
             Items="_tabs"
             DefaultActiveKey="anniversary"

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoAnniversaryPage.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoAnniversaryPage.razor.css
@@ -1,4 +1,18 @@
-﻿.expo-anniversary-page {
+﻿.banner-image {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    max-width: 800px;
+    margin-bottom: 2rem;
+}
+
+.banner-image img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+}
+
+.expo-anniversary-page {
     display: flex;
     flex-direction: column;
     align-items: center;

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoLotteryPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoLotteryPage.razor
@@ -8,6 +8,11 @@
 <CgPageMeta Title="CNGAL周年庆展示会 - 预约抽奖" />
 
 <div class="expo-lottery-page">
+    <div class="banner-image">
+        <a href="https://space.bilibili.com/145239325/dynamic" target="_blank">
+            <img src="https://image.cngal.org/images/upload/20260719/5dadcb55f02d86dce9548e68a907226ddeab3417.jpg" alt="展会横幅" />
+        </a>
+    </div>
     <CgTabs Variant="underline"
             Items="_tabs"
             DefaultActiveKey="lottery"

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoLotteryPage.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoLotteryPage.razor.css
@@ -14,6 +14,20 @@
     align-items: center;
 }
 
+.banner-image {
+    display: flex;
+    justify-content: center;
+    width: 100%;
+    max-width: 800px;
+    margin-bottom: 2rem;
+}
+
+.banner-image img {
+    width: 100%;
+    height: auto;
+    border-radius: 8px;
+}
+
 .title-card {
     display: flex;
     justify-content: center;


### PR DESCRIPTION
在 ExpoAnniversaryPage.razor 和 ExpoLotteryPage.razor 页面顶部添加了横幅图片区域（banner-image），点击图片可跳转至 Bilibili 动态页面。新增相关 CSS 样式，优化横幅居中、宽度和圆角显示，提升视觉效果，保持原有功能不变。