### PR TITLE
更换展会横幅图片为代理接口加载

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoAnniversaryPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoAnniversaryPage.razor
@@ -8,7 +8,7 @@
 <div class="expo-anniversary-page">
     <div class="banner-image">
         <a href="https://space.bilibili.com/145239325/dynamic" target="_blank">
-            <img src="https://image.cngal.org/images/upload/20260719/5dadcb55f02d86dce9548e68a907226ddeab3417.jpg" alt="展会横幅" />
+            <img src="https://tucang.cngal.top/api/image/show/2817a8828a8538ecaf6f499341815009?https://image.cngal.org/images/upload/20260719/5dadcb55f02d86dce9548e68a907226ddeab3417.jpg" alt="展会横幅" />
         </a>
     </div>
     <CgTabs Variant="underline"

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoLotteryPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoLotteryPage.razor
@@ -10,7 +10,7 @@
 <div class="expo-lottery-page">
     <div class="banner-image">
         <a href="https://space.bilibili.com/145239325/dynamic" target="_blank">
-            <img src="https://image.cngal.org/images/upload/20260719/5dadcb55f02d86dce9548e68a907226ddeab3417.jpg" alt="展会横幅" />
+            <img src="https://tucang.cngal.top/api/image/show/2817a8828a8538ecaf6f499341815009?https://image.cngal.org/images/upload/20260719/5dadcb55f02d86dce9548e68a907226ddeab3417.jpg" alt="展会横幅" />
         </a>
     </div>
     <CgTabs Variant="underline"


### PR DESCRIPTION
将 ExpoAnniversaryPage.razor 和 ExpoLotteryPage.razor 文件中展会横幅图片的 src 链接由 image.cngal.org 更改为 tucang.cngal.top 图片代理接口，图片内容未变，仅调整加载方式以优化访问体验。