### PR TITLE
放宽周年庆页面访问权限，调整导航栏显示

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Layout/MainLayout.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Layout/MainLayout.razor
@@ -26,11 +26,7 @@
                     <a href="/lotteries/home">抽奖</a>
                     <a href="/square">广场</a>
                     <a href="/sharegames">分享游玩记录</a>
-                    <AuthorizeView Roles="Admin">
-                        <Authorized> 
                             <a href="/11th">周年庆</a>
-                        </Authorized>
-                    </AuthorizeView>
                 </nav>
             </div>
 

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoAnniversaryPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoAnniversaryPage.razor
@@ -1,5 +1,4 @@
 ﻿@page "/expo/anniversary"
-@attribute [Authorize(Roles = "Admin")]
 
 @rendermode InteractiveServer
 

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoLotteryPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Expo/ExpoLotteryPage.razor
@@ -1,6 +1,5 @@
 ﻿@page "/expo/lottery"
 @page "/11th"
-@attribute [Authorize(Roles = "Admin")]
 @rendermode InteractiveServer
 @inject IExpoQueryService ExpoQueryService
 @inject ICgToastService ToastService


### PR DESCRIPTION
移除了“周年庆”及“周年庆抽奖”页面的管理员权限限制，所有用户均可访问。主导航栏中删除了仅管理员可见的“周年庆”导航链接，普通用户无法通过导航栏进入该页面。