### PR TITLE
统一卡片背景色为主题变量并优化跳转链接

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Expo/AnniversaryCard.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Expo/AnniversaryCard.razor.css
@@ -50,7 +50,7 @@
 
 
 ::deep .lottery-award-card {
-    background: white;
+    background: var(--cg-color-surface);
 }
 
 ::deep .lottery-award-list {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Expo/GridCard.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Expo/GridCard.razor.css
@@ -4,7 +4,7 @@
     border: 2px solid transparent;
     background-clip: padding-box, border-box;
     background-origin: padding-box, border-box;
-    background-image: linear-gradient(to right, #ffffff, #ffffff), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
+    background-image: linear-gradient(to right, var(--cg-color-surface), var(--cg-color-surface)), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
     border-radius: 12px;
 }
 
@@ -17,7 +17,7 @@
     border: 2px solid transparent;
     background-clip: padding-box, border-box;
     background-origin: padding-box, border-box;
-    background-image: linear-gradient(to right, #ffffff, #ffffff), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
+    background-image: linear-gradient(to right, var(--cg-color-surface), var(--cg-color-surface)), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
     border-radius: 12px;
     margin-right: 1rem;
     margin-top: .5rem;
@@ -33,7 +33,7 @@
     width: 30px;
     height: 30px;
     color: var(--cg-color-primary) !important;
-    background-color: white;
+    background-color: var(--cg-color-surface);
 }
 
 .lottery-grid-card .count-card div {
@@ -94,12 +94,12 @@
 
 /* 禁用状态的抽奖按钮 */
 .lottery-grid-card .action-card.disabled > div {
-    background-image: linear-gradient(135deg, #999999, #666666);
+    background-image: linear-gradient(135deg, var(--cg-color-text-muted), color-mix(in oklab, var(--cg-color-text-muted) 60%, transparent));
     cursor: not-allowed;
 }
 
 .lottery-grid-card .action-card.disabled > div:hover {
-    background-image: linear-gradient(135deg, #999999, #666666);
+    background-image: linear-gradient(135deg, var(--cg-color-text-muted), color-mix(in oklab, var(--cg-color-text-muted) 60%, transparent));
 }
 
 .lottery-grid-card .divid-card {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Expo/TasksCard.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Expo/TasksCard.razor
@@ -139,7 +139,7 @@
                 Name = "绑定群聊QQ",
                 Points = 20,
                 IsCompleted = Model.IsBindQQ,
-                Link = "https://app.cngal.org/space/editdata",
+                Link = "/space/edit",
                 OnClick = OnClickBindQQAsync
             },
             new()
@@ -147,7 +147,7 @@
                 Name = "更换默认头像",
                 Points = 20,
                 IsCompleted = Model.IsChangeAvatar,
-                Link = "https://app.cngal.org/space/editdata",
+                Link = "/space/edit",
                 OnClick = OnClickChangeAvatarAsync
             },
             new()
@@ -155,7 +155,7 @@
                 Name = "更换默认签名",
                 Points = 20,
                 IsCompleted = Model.IsChangeSignature,
-                Link = "https://app.cngal.org/space/editdata",
+                Link = "/space/edit",
                 OnClick = OnClickChangeSignatureAsync
             },
             new()
@@ -311,7 +311,7 @@
         catch { /* fall through */ }
 
         ToastService.Show("提示", "请先绑定群聊QQ后再领取奖励", "info");
-        await JS.InvokeVoidAsync("window.open", "https://app.cngal.org/space/editdata", "_blank");
+        await JS.InvokeVoidAsync("window.open", "/space/edit", "_blank");
     }
 
     private async Task OnClickChangeAvatarAsync()
@@ -331,7 +331,7 @@
         catch { /* fall through */ }
 
         ToastService.Show("提示", "请先更换默认头像后再领取奖励", "info");
-        await JS.InvokeVoidAsync("window.open", "https://app.cngal.org/space/editdata", "_blank");
+        await JS.InvokeVoidAsync("window.open", "/space/edit", "_blank");
     }
 
     private async Task OnClickChangeSignatureAsync()
@@ -351,7 +351,7 @@
         catch { /* fall through */ }
 
         ToastService.Show("提示", "请先更换默认签名后再领取奖励", "info");
-        await JS.InvokeVoidAsync("window.open", "https://app.cngal.org/space/editdata", "_blank");
+        await JS.InvokeVoidAsync("window.open", "/space/edit", "_blank");
     }
 
     private async Task OnClickSaveGGenerationAsync()

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Expo/TasksCard.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Expo/TasksCard.razor.css
@@ -9,7 +9,7 @@
     border: 2px solid transparent;
     background-clip: padding-box, border-box;
     background-origin: padding-box, border-box;
-    background-image: linear-gradient(to right, #ffffff, #ffffff), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
+    background-image: linear-gradient(to right, var(--cg-color-surface), var(--cg-color-surface)), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
     border-top-right-radius: 24px;
 }
 
@@ -40,7 +40,7 @@
     border: 2px solid transparent;
     background-clip: padding-box, border-box;
     background-origin: padding-box, border-box;
-    background-image: linear-gradient(to right, #ffffff, #ffffff), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
+    background-image: linear-gradient(to right, var(--cg-color-surface), var(--cg-color-surface)), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
     padding: .5rem 3rem;
     display: flex;
     align-items: center;
@@ -70,7 +70,7 @@
     border-radius: 50%;
     background-clip: padding-box, border-box;
     background-origin: padding-box, border-box;
-    background-image: linear-gradient(to right, #ffffff, #ffffff), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
+    background-image: linear-gradient(to right, var(--cg-color-surface), var(--cg-color-surface)), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
     color: var(--cg-color-primary) !important;
     width: 36px;
     height: 36px;
@@ -96,7 +96,7 @@
     border-radius: 50%;
     background-clip: padding-box, border-box;
     background-origin: padding-box, border-box;
-    background-image: linear-gradient(to right, #ffffff, #ffffff), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
+    background-image: linear-gradient(to right, var(--cg-color-surface), var(--cg-color-surface)), linear-gradient(45deg, var(--cg-color-primary) 0%, var(--cg-color-primary-hover) 100%);
     padding: 2px;
     position: relative;
 }

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Lottery/Draw/LotteryAnimationCard.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Lottery/Draw/LotteryAnimationCard.razor.css
@@ -43,6 +43,7 @@
         font-size: 72px;
         text-align: center;
         line-height: 163px;
+        color: #0f172a;
     }
 
 .slot1 {


### PR DESCRIPTION
- 将卡片、按钮等背景色统一为 CSS 变量 `--cg-color-surface`，提升主题适配性
- 优化禁用抽奖按钮样式，使用主题色变量和 `color-mix`
- TasksCard 跳转链接由绝对地址改为相对地址，调整 JS 跳转逻辑，提升环境兼容性
- 优化 LotteryAnimationCard 数字字体颜色，增强可读性