### PR TITLE
fix: 完善 HTML 安全过滤与富文本渲染

### DIFF
--- a/CnGalWebSite/CnGalWebSite.APIServer/Application/Entries/EntryService.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Application/Entries/EntryService.cs
@@ -1178,7 +1178,7 @@ namespace CnGalWebSite.APIServer.Application.Entries
                 {
                     Icon = "mdi-card-account-details-outline",
                     Name = "别称",
-                    Value = model.AnotherName,
+                    Value = HtmlSanitizerHelper.Sanitize(model.AnotherName),
                 });
             }
             //添加角色CV
@@ -1199,7 +1199,7 @@ namespace CnGalWebSite.APIServer.Application.Entries
                     {
                         Icon = "mdi-microphone",
                         Name = "配音",
-                        Value = cvs.ToString()
+                        Value = HtmlSanitizerHelper.Sanitize(cvs.ToString())
                     });
                 }
 
@@ -1216,11 +1216,11 @@ namespace CnGalWebSite.APIServer.Application.Entries
                     {
                         Icon = info.Icon,
                         Name = item.DisplayName,
-                        Value = item.DisplayValue
+                        Value = HtmlSanitizerHelper.Sanitize(item.DisplayValue)
                     };
                     if(temp.Name== "QQ群")
                     {
-                        temp.Value = QQGroupRegex().Replace(temp.Value, "<b>$1</b>");
+                        temp.Value = HtmlSanitizerHelper.Sanitize(QQGroupRegex().Replace(temp.Value, "<b>$1</b>"));
                     }
                     model.Information.Add(temp);
                 }
@@ -1242,11 +1242,11 @@ namespace CnGalWebSite.APIServer.Application.Entries
                     {
                         Name = model.Information.Any(s => s.Name == "QQ群") ? item.DisplayName : "QQ群",
                         Icon = model.Information.Any(s => s.Name == "QQ群") ? "mdi-vector-point" : qqIcon,
-                        Value = model.Information.Any(s => s.Name == "QQ群") ? item.Information.FirstOrDefault(s => s.DisplayName == "QQ群").DisplayValue : $"{item.Information.FirstOrDefault(s => s.DisplayName == "QQ群").DisplayValue} ({item.DisplayName})"
+                        Value = HtmlSanitizerHelper.Sanitize(model.Information.Any(s => s.Name == "QQ群") ? item.Information.FirstOrDefault(s => s.DisplayName == "QQ群").DisplayValue : $"{item.Information.FirstOrDefault(s => s.DisplayName == "QQ群").DisplayValue} ({item.DisplayName})")
                     };
 
 
-                    temp.Value = QQGroupRegex().Replace(temp.Value, "<b>$1</b>");
+                    temp.Value = HtmlSanitizerHelper.Sanitize(QQGroupRegex().Replace(temp.Value, "<b>$1</b>"));
                     model.Information.Add(temp);
                 }
             }

--- a/CnGalWebSite/CnGalWebSite.APIServer/Application/Examines/ExamineService.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Application/Examines/ExamineService.cs
@@ -225,7 +225,7 @@ namespace CnGalWebSite.APIServer.Application.Examines
 
         public async Task<bool> GetExamineView(ExamineViewModel model, Examine examine)
         {
-            return examine.Operation switch
+            var success = examine.Operation switch
             {
                 Operation.UserMainPage => GetUserMainPageExamineView(model, examine),
                 Operation.EditUserMain => await GetEditUserMainExamineView(model, examine),
@@ -259,6 +259,15 @@ namespace CnGalWebSite.APIServer.Application.Examines
                 Operation.EstablishWebsite => await GetEstablishWebsiteExamineView(model, examine),
                 _ => false,
             };
+            if (success)
+            {
+                model.EditOverview = HtmlSanitizerHelper.Sanitize(model.EditOverview);
+                if (model.BeforeModel != null)
+                    model.BeforeModel.MainPage = HtmlSanitizerHelper.Sanitize(model.BeforeModel.MainPage);
+                if (model.AfterModel != null)
+                    model.AfterModel.MainPage = HtmlSanitizerHelper.Sanitize(model.AfterModel.MainPage);
+            }
+            return success;
         }
 
         public async Task<List<ExaminedNormalListModel>> GetExaminesToNormalListAsync(IQueryable<Examine> examines, bool isShowRanks)

--- a/CnGalWebSite/CnGalWebSite.APIServer/Application/Helper/AppHelper.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Application/Helper/AppHelper.cs
@@ -629,7 +629,7 @@ namespace CnGalWebSite.APIServer.Application.Helper
                 .UseFigures().Build();
             var html = Markdown.ToHtml(sb.ToString(), pipeline);
             html = AddLazyLoading(html);
-            return html;
+            return HtmlSanitizerHelper.Sanitize(html);
         }
 
         private string AddLazyLoading(string html)

--- a/CnGalWebSite/CnGalWebSite.APIServer/Application/Helper/HtmlSanitizerHelper.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Application/Helper/HtmlSanitizerHelper.cs
@@ -1,0 +1,157 @@
+using Ganss.Xss;
+using System;
+using System.Linq;
+
+namespace CnGalWebSite.APIServer.Application.Helper
+{
+    /// <summary>
+    /// HTML 净化器：所有 Markdown 渲染结果在返回前端前统一经过白名单净化，防止存储型 XSS。
+    /// 允许常见排版标签与属性；iframe 校验受信任平台的初始地址，不限制后续重定向；危险协议一律剥离。
+    /// </summary>
+    public static class HtmlSanitizerHelper
+    {
+        private static readonly HtmlSanitizer _sanitizer = CreateSanitizer();
+
+        public static string Sanitize(string html)
+        {
+            return string.IsNullOrWhiteSpace(html) ? html : _sanitizer.Sanitize(html);
+        }
+
+        private static HtmlSanitizer CreateSanitizer()
+        {
+            var sanitizer = new HtmlSanitizer();
+
+            sanitizer.AllowedTags.Clear();
+            foreach (var tag in new[]
+            {
+                "a","abbr","audio","b","bdi","bdo","blockquote","br","caption","center","cite","code","col","colgroup",
+                "dd","del","details","dfn","div","dl","dt","em","figcaption","figure","font","h1","h2","h3","h4","h5","h6",
+                "hr","i","iframe","img","input","ins","kbd","li","mark","ol","p","picture","pre","q","rp","rt","ruby","s","samp",
+                "small","source","span","strike","strong","sub","summary","sup","table","tbody","td","tfoot","th","thead",
+                "tr","u","ul","var","video",
+                "article","aside","footer","header","main","nav","section"
+            })
+            {
+                sanitizer.AllowedTags.Add(tag);
+            }
+
+            sanitizer.AllowedAttributes.Clear();
+            // srcset remains excluded: control-character candidates can be rewritten into extra URLs.
+            foreach (var attr in new[]
+            {
+                "abbr","align","allow","allowfullscreen","alt","autoplay","border","cellpadding","cellspacing","charset",
+                "cite","class","colspan","controls","datetime","dir","download","frameborder","framespacing","headers",
+                "height","href","hreflang","hspace","id","lang","loading","loop","media","muted","name","playsinline",
+                "poster","preload","rel","rowspan","scope","scrolling","size","span","src","start","target","title","type",
+                "valign","vspace","width","style","checked","disabled","crossorigin"
+            })
+            {
+                sanitizer.AllowedAttributes.Add(attr);
+            }
+
+            sanitizer.AllowedSchemes.Clear();
+            foreach (var scheme in new[] { "http", "https", "mailto" })
+            {
+                sanitizer.AllowedSchemes.Add(scheme);
+            }
+
+            sanitizer.AllowDataAttributes = false;
+
+            // Media must not inherit mailto support from ordinary hyperlinks.
+            var mediaBaseUri = new Uri("https://sanitizer.invalid/");
+            sanitizer.FilterUrl += (_, e) =>
+            {
+                if (e.Tag.LocalName is "img" or "source" or "audio" or "video"
+                    && e.SanitizedUrl != null
+                    && (!Uri.TryCreate(mediaBaseUri, e.SanitizedUrl, out var uri)
+                        || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps)))
+                {
+                    e.SanitizedUrl = null;
+                }
+            };
+
+            sanitizer.AllowedCssProperties.Clear();
+            sanitizer.AllowedCssProperties.UnionWith(new[]
+            {
+                "color", "background-color", "text-align", "font-weight", "font-style", "text-decoration",
+                "text-decoration-line", "text-decoration-style", "text-decoration-color"
+            });
+
+            // Preserve task-list state without allowing interactive form controls.
+            sanitizer.PostProcessNode += (_, e) =>
+            {
+                if (e.Node is AngleSharp.Html.Dom.IHtmlElement media)
+                {
+                    if (media.HasAttribute("crossorigin"))
+                    {
+                        var value = media.GetAttribute("crossorigin");
+                        if (media.LocalName is "img" or "audio" or "video"
+                            && (value == "" || string.Equals(value, "anonymous", StringComparison.OrdinalIgnoreCase)))
+                        {
+                            media.SetAttribute("crossorigin", "anonymous");
+                        }
+                        else
+                        {
+                            media.RemoveAttribute("crossorigin");
+                        }
+                    }
+                }
+
+                if (e.Node is AngleSharp.Html.Dom.IHtmlElement input
+                    && string.Equals(input.TagName, "INPUT", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (!string.Equals(input.GetAttribute("type"), "checkbox", StringComparison.OrdinalIgnoreCase))
+                    {
+                        input.Remove();
+                        return;
+                    }
+                    foreach (var attribute in input.Attributes.ToArray())
+                    {
+                        if (attribute.Name != "type" && attribute.Name != "checked")
+                        {
+                            input.RemoveAttribute(attribute.Name);
+                        }
+                    }
+                    input.SetAttribute("disabled", "");
+                }
+
+                if (e.Node is AngleSharp.Html.Dom.IHtmlElement element
+                    && string.Equals(element.TagName, "IFRAME", StringComparison.OrdinalIgnoreCase))
+                {
+                    var ok = false;
+                    var src = element.GetAttribute("src");
+                    if (src?.StartsWith("//", StringComparison.Ordinal) == true)
+                    {
+                        src = "https:" + src;
+                    }
+                    if (Uri.TryCreate(src, UriKind.Absolute, out var uri)
+                        && uri.Scheme == Uri.UriSchemeHttps && uri.IsDefaultPort
+                        && string.IsNullOrEmpty(uri.UserInfo))
+                    {
+                        ok = new[] { "bilibili.com", "b23.tv", "weibo.com", "weibo.cn", "youtube.com" }
+                            .Any(host => uri.Host.Equals(host, StringComparison.OrdinalIgnoreCase)
+                                || uri.Host.EndsWith("." + host, StringComparison.OrdinalIgnoreCase));
+                    }
+                    if (!ok)
+                    {
+                        element.Remove();
+                        return;
+                    }
+                    element.SetAttribute("src", src);
+                    element.SetAttribute("loading", "lazy");
+                    element.SetAttribute("allow", "fullscreen");
+                    element.SetAttribute("referrerpolicy", "strict-origin-when-cross-origin");
+                }
+
+                if (e.Node is AngleSharp.Html.Dom.IHtmlElement link
+                    && string.Equals(link.TagName, "A", StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(link.GetAttribute("target"), "_blank", StringComparison.OrdinalIgnoreCase))
+                {
+                    link.SetAttribute("rel", "noopener noreferrer");
+                }
+            };
+
+            return sanitizer;
+        }
+    }
+}

--- a/CnGalWebSite/CnGalWebSite.APIServer/Application/Messages/MessageService.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Application/Messages/MessageService.cs
@@ -1,5 +1,6 @@
 ﻿
 using CnGalWebSite.APIServer.Application.Users.Dtos;
+using CnGalWebSite.APIServer.Application.Helper;
 using CnGalWebSite.APIServer.DataReositories;
 
 using CnGalWebSite.DataModel.ViewModel.Admin;
@@ -64,7 +65,7 @@ namespace CnGalWebSite.APIServer.Application.Messages
                 //提前将MarkDown语法转为Html
 
                 var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseSoftlineBreakAsHardlineBreak().Build();
-                item.Text = Markdig.Markdown.ToHtml(item.Text ?? "", pipeline);
+                item.Text = HtmlSanitizerHelper.Sanitize(Markdig.Markdown.ToHtml(item.Text ?? "", pipeline));
             }
 
             var dtos = new PagedResultDto<DataModel.Model.Message>

--- a/CnGalWebSite/CnGalWebSite.APIServer/CnGalWebSite.APIServer.csproj
+++ b/CnGalWebSite/CnGalWebSite.APIServer/CnGalWebSite.APIServer.csproj
@@ -33,6 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="htmldiff.net" Version="1.5.0" />
+    <PackageReference Include="HtmlSanitizer" Version="9.2.995" />
     <PackageReference Include="IdentityModel" Version="7.0.0" />
     <PackageReference Include="Markdig" Version="0.43.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/ArticlesAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/ArticlesAPIController.cs
@@ -1244,7 +1244,7 @@ namespace CnGalWebSite.APIServer.Controllers
                 foreach (var infor in item.Articles)
                 {
                     var infor1 = _appHelper.GetArticleInforTipViewModel(infor);
-                    infor1.BriefIntroduction = Markdown.ToHtml(infor.MainPage ?? "", pipeline);
+                    infor1.BriefIntroduction = HtmlSanitizerHelper.Sanitize(Markdown.ToHtml(infor.MainPage ?? "", pipeline));
 
                     temp.Evaluations.Add(infor1);
                 }

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/LotteryAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/LotteryAPIController.cs
@@ -210,7 +210,7 @@ namespace CnGalWebSite.APIServer.Controllers
             };
             //初始化主页Html代码
             var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseSoftlineBreakAsHardlineBreak().Build();
-            model.MainPage = Markdown.ToHtml(model.MainPage ?? "", pipeline);
+            model.MainPage = HtmlSanitizerHelper.Sanitize(Markdown.ToHtml(model.MainPage ?? "", pipeline));
 
             //可能需要添加检测抽奖是否结束
             foreach (var item in lottery.Awards.OrderByDescending(s => s.Priority))

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/NewsAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/NewsAPIController.cs
@@ -331,7 +331,7 @@ namespace CnGalWebSite.APIServer.Controllers
 
             //初始化主页Html代码
             var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseSoftlineBreakAsHardlineBreak().Build();
-            model.MainPage = Markdown.ToHtml(model.MainPage ?? "", pipeline);
+            model.MainPage = HtmlSanitizerHelper.Sanitize(Markdown.ToHtml(model.MainPage ?? "", pipeline));
 
             //走动态的作者初始化流程
             var infor = await _articleService.GetNewsModelAsync(article);
@@ -535,7 +535,7 @@ namespace CnGalWebSite.APIServer.Controllers
 
             //初始化主页Html代码
             var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseSoftlineBreakAsHardlineBreak().Build();
-            model.MainPage = Markdown.ToHtml(model.MainPage ?? "", pipeline);
+            model.MainPage = HtmlSanitizerHelper.Sanitize(Markdown.ToHtml(model.MainPage ?? "", pipeline));
 
             return model;
 

--- a/CnGalWebSite/CnGalWebSite.APIServer/Controllers/VoteAPIController.cs
+++ b/CnGalWebSite/CnGalWebSite.APIServer/Controllers/VoteAPIController.cs
@@ -125,7 +125,7 @@ namespace CnGalWebSite.APIServer.Controllers
             }
             //初始化主页Html代码
             var pipeline = new MarkdownPipelineBuilder().UseAdvancedExtensions().UseSoftlineBreakAsHardlineBreak().Build();
-            model.MainPage = Markdown.ToHtml(model.MainPage ?? "", pipeline);
+            model.MainPage = HtmlSanitizerHelper.Sanitize(Markdown.ToHtml(model.MainPage ?? "", pipeline));
 
             foreach (var item in vote.Entries)
             {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/DesignSystem/CgHtmlContent.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/DesignSystem/CgHtmlContent.razor
@@ -1,61 +1,17 @@
 @* CgHtmlContent — 通用 HTML 内容显示组件，用于渲染 markdown 解析生成的 HTML *@
-@using System.Text.RegularExpressions
 
 @if (!string.IsNullOrWhiteSpace(Content))
 {
     <div class="cg-html-content">
-        @(new MarkupString(Sanitize(Content)))
+        @(new MarkupString(Content))
     </div>
 }
 
 @code {
     /// <summary>
-    /// 要渲染的 HTML 内容字符串（通常由 markdown 解析生成）
+    /// 已由服务端完成净化的 HTML；此组件不接受原始用户输入。
     /// </summary>
     [Parameter]
     public string? Content { get; set; }
 
-    private static readonly Regex _scriptRegex = new(
-        @"<script[\s>].*?</script\s*>",
-        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
-
-    private static readonly Regex _iframeRegex = new(
-        @"<iframe[\s>].*?</iframe\s*>",
-        RegexOptions.IgnoreCase | RegexOptions.Singleline | RegexOptions.Compiled);
-
-    private static readonly Regex _containerCloseRegex = new(
-        @"</(div|section|main|article|header|footer|nav|aside|html|body|head)\s*>",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    private static readonly Regex _aOpenRegex = new(
-        @"<\s*a\b[^>]*>",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    private static readonly Regex _aCloseRegex = new(
-        @"<\s*/\s*a\s*>",
-        RegexOptions.IgnoreCase | RegexOptions.Compiled);
-
-    private static string Sanitize(string html)
-    {
-        if (string.IsNullOrWhiteSpace(html))
-        {
-            return html;
-        }
-
-        html = _scriptRegex.Replace(html, string.Empty);
-        html = _iframeRegex.Replace(html, string.Empty);
-
-        // 转义会破坏外层容器结构的关闭标签，防止 HTML 内容突破 DOM 容器
-        html = _containerCloseRegex.Replace(html, "&lt;/$1&gt;");
-
-        // 补全未闭合的 <a> 标签，防止后续内容被错误包裹
-        var openCount = _aOpenRegex.Count(html);
-        var closeCount = _aCloseRegex.Count(html);
-        if (openCount > closeCount)
-        {
-            html += string.Concat(Enumerable.Repeat("</a>", openCount - closeCount));
-        }
-
-        return html;
-    }
 }

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/DesignSystem/CgHtmlContent.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/DesignSystem/CgHtmlContent.razor.css
@@ -72,6 +72,30 @@
     margin: 1em 0;
 }
 
+.cg-html-content ::deep video,
+.cg-html-content ::deep audio {
+    max-width: 100%;
+}
+
+.cg-html-content ::deep video {
+    height: auto;
+}
+
+.cg-html-content ::deep .aspect-ratio {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56%;
+}
+
+.cg-html-content ::deep .aspect-ratio iframe {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
+}
+
 /* ── 行内代码 ── */
 .cg-html-content ::deep code {
     background: var(--cg-color-section-bg);

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Entry/Editor/EntryWebsiteEditor.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Entry/Editor/EntryWebsiteEditor.razor
@@ -91,16 +91,14 @@
 
         @* ── HTML 编辑区 ── *@
         <CgAlert Variant="warning">
-            SSR模式下会拦截不受信任的源和内联脚本，请与管理员联系以添加脚本
+            HTML 预览在隔离环境中显示，不执行脚本，也不继承主站样式。
         </CgAlert>
 
         <CgFormGroup Label="自定义 Html（将会覆盖整个页面）">
             <CgTextarea @bind-Value="Model.Html" Placeholder="在此输入自定义的网页 HTML 代码" Rows="6" Monospace />
             @if (!string.IsNullOrWhiteSpace(Model.Html))
             {
-                <div class="cg-html-preview">
-                    @((MarkupString)Model.Html)
-                </div>
+                <iframe class="cg-html-preview" title="自定义页面预览" sandbox="" srcdoc="@Model.Html"></iframe>
             }
         </CgFormGroup>
 
@@ -108,9 +106,7 @@
             <CgTextarea @bind-Value="Model.FirstPage" Placeholder="可选，覆盖专题首页内容" Rows="5" Monospace />
             @if (!string.IsNullOrWhiteSpace(Model.FirstPage))
             {
-                <div class="cg-html-preview">
-                    @((MarkupString)Model.FirstPage)
-                </div>
+                <iframe class="cg-html-preview" title="自定义首页预览" sandbox="" srcdoc="@Model.FirstPage"></iframe>
             }
         </CgFormGroup>
 
@@ -118,9 +114,7 @@
             <CgTextarea @bind-Value="Model.Introduction" Placeholder="可选，覆盖专题介绍内容" Rows="5" Monospace />
             @if (!string.IsNullOrWhiteSpace(Model.Introduction))
             {
-                <div class="cg-html-preview">
-                    @((MarkupString)Model.Introduction)
-                </div>
+                <iframe class="cg-html-preview" title="自定义介绍预览" sandbox="" srcdoc="@Model.Introduction"></iframe>
             }
         </CgFormGroup>
     }

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Entry/Editor/EntryWebsiteEditor.razor.css
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Entry/Editor/EntryWebsiteEditor.razor.css
@@ -27,6 +27,8 @@
 
 /* ── HTML 预览 ── */
 .cg-html-preview {
+    width: 100%;
+    height: 400px;
     margin-top: var(--cg-spacing-3);
     padding: var(--cg-spacing-4);
     border: 1px solid var(--cg-color-border);

--- a/CnGalWebSite/CnGalWebSite.UnitTest/CnGalWebSite.UnitTest.csproj
+++ b/CnGalWebSite/CnGalWebSite.UnitTest/CnGalWebSite.UnitTest.csproj
@@ -10,6 +10,9 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Include="../CnGalWebSite.APIServer/Application/Helper/HtmlSanitizerHelper.cs" Link="HtmlSanitizerHelper.cs" />
+    <PackageReference Include="HtmlSanitizer" Version="9.2.995" />
+    <PackageReference Include="Markdig" Version="0.43.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.2.0" />

--- a/CnGalWebSite/CnGalWebSite.UnitTest/HtmlSanitizerBrowserTests.cs
+++ b/CnGalWebSite/CnGalWebSite.UnitTest/HtmlSanitizerBrowserTests.cs
@@ -1,0 +1,217 @@
+using System.Text;
+using System.Net;
+using System.Net.Sockets;
+using CnGalWebSite.APIServer.Application.Helper;
+using Microsoft.Playwright;
+using NUnit.Framework;
+
+namespace CnGalWebSite.UnitTest;
+
+[TestFixture]
+[Category("Browser")]
+public class HtmlSanitizerBrowserTests
+{
+    [SetUp]
+    public void RequireExplicitOptIn()
+    {
+        if (!string.Equals(Environment.GetEnvironmentVariable("RUN_HTML_SANITIZER_BROWSER_TESTS"), "1", StringComparison.Ordinal))
+            Assert.Ignore("Set RUN_HTML_SANITIZER_BROWSER_TESTS=1 to run Playwright compatibility tests.");
+    }
+
+    private sealed class FixtureServer : IAsyncDisposable
+    {
+        private readonly TcpListener _listener = new(IPAddress.Loopback, 0);
+        private readonly CancellationTokenSource _stop = new();
+        private readonly Task _loop;
+        private readonly List<Task> _connections = new();
+        public string Origin { get; }
+
+        public FixtureServer()
+        {
+            _listener.Start();
+            Origin = $"http://127.0.0.1:{((IPEndPoint)_listener.LocalEndpoint).Port}";
+            _loop = RunAsync();
+        }
+
+        private async Task RunAsync()
+        {
+            try
+            {
+                while (!_stop.IsCancellationRequested)
+                {
+                    var client = await _listener.AcceptTcpClientAsync(_stop.Token);
+                    _connections.Add(HandleAsync(client));
+                }
+            }
+            catch (OperationCanceledException) { }
+        }
+
+        private async Task HandleAsync(TcpClient client)
+        {
+            using (client)
+            {
+                try
+                {
+                    await using var stream = client.GetStream();
+                    using var reader = new StreamReader(stream, leaveOpen: true);
+                    var request = await reader.ReadLineAsync(_stop.Token);
+                    if (request == null)
+                        return;
+                    while (!string.IsNullOrEmpty(await reader.ReadLineAsync(_stop.Token))) { }
+                    var path = request.Split(' ')[1];
+                    var image = path.EndsWith(".png");
+                    var audio = path.EndsWith(".wav");
+                    var body = image
+                        ? Convert.FromBase64String("iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAIAAAD91JpzAAAAFklEQVR4nGO4Y2QktyCFwSjlzod9GgAkqAWrQxfoeAAAAABJRU5ErkJggg==")
+                        : audio ? Tone() : Encoding.UTF8.GetBytes("<!doctype html><html><body></body></html>");
+                    var type = image ? "image/png" : audio ? "audio/wav" : "text/html";
+                    var cors = path.Contains("deny") ? "" : "Access-Control-Allow-Origin: *\r\n";
+                    var headers = Encoding.ASCII.GetBytes($"HTTP/1.1 200 OK\r\nContent-Type: {type}\r\nContent-Length: {body.Length}\r\n{cors}Connection: close\r\n\r\n");
+                    await stream.WriteAsync(headers, _stop.Token);
+                    await stream.WriteAsync(body, _stop.Token);
+                }
+                catch (OperationCanceledException) { }
+                catch (IOException) { } // Browsers may cancel speculative or CORS-denied requests.
+            }
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _stop.CancelAsync();
+            await _loop;
+            await Task.WhenAll(_connections);
+            _listener.Stop();
+            _stop.Dispose();
+        }
+    }
+
+    private static byte[] Tone()
+    {
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        writer.Write(Encoding.ASCII.GetBytes("RIFF"));
+        writer.Write(36 + 16000);
+        writer.Write(Encoding.ASCII.GetBytes("WAVEfmt "));
+        writer.Write(16);
+        writer.Write((short)1);
+        writer.Write((short)1);
+        writer.Write(8000);
+        writer.Write(16000);
+        writer.Write((short)2);
+        writer.Write((short)16);
+        writer.Write(Encoding.ASCII.GetBytes("data"));
+        writer.Write(16000);
+        for (var i = 0; i < 8000; i++)
+            writer.Write((short)(Math.Sin(i * Math.PI * 440 / 4000) * 1000));
+        return stream.ToArray();
+    }
+
+    [TestCase("chromium", 1280)]
+    [TestCase("chromium", 390)]
+    [TestCase("firefox", 1280)]
+    [TestCase("firefox", 390)]
+    [TestCase("webkit", 1280)]
+    [TestCase("webkit", 390)]
+    public async Task IsolatedMediaAndFormatting(string engine, int width)
+    {
+        using var playwright = await Playwright.CreateAsync();
+        await using var site = new FixtureServer();
+        await using var media = new FixtureServer();
+        var browserType = engine switch
+        {
+            "firefox" => playwright.Firefox,
+            "webkit" => playwright.Webkit,
+            _ => playwright.Chromium
+        };
+        await using var browser = await browserType.LaunchAsync(new() { Headless = true });
+        await using var context = await browser.NewContextAsync(new()
+        {
+            ViewportSize = new() { Width = width, Height = 900 },
+            DeviceScaleFactor = 1,
+            ServiceWorkers = ServiceWorkerPolicy.Block
+        });
+        var requests = new List<string>();
+        await context.RouteAsync("**/*", async route =>
+        {
+            var uri = new Uri(route.Request.Url);
+            requests.Add(uri.AbsolutePath);
+            if (uri.GetLeftPart(UriPartial.Authority) != site.Origin
+                && uri.GetLeftPart(UriPartial.Authority) != media.Origin)
+            {
+                await route.AbortAsync();
+                return;
+            }
+            await route.ContinueAsync();
+        });
+        var page = await context.NewPageAsync();
+        await page.GotoAsync(site.Origin);
+        var html = """
+            <h1>Media compatibility audit</h1>
+            <p id="decoration" style="text-decoration:line-through;color:red">Entry 42: text decoration</p>
+            <picture><source media="(max-width:600px)" srcset="/small.png 1x, /large.png 2x">
+              <img id="responsive" src="/fallback.png" width="180" height="100" alt="Entry 6445 responsive image"></picture>
+            <picture><source srcset="javascript:alert(1) 1x">
+              <img id="fallback" src="/fallback.png" width="180" height="100" alt="Fallback image"></picture>
+            <img id="cors-ok" crossorigin="" src="http://media.test/ok.png" alt="Anonymous CORS allowed">
+            <img id="cors-deny" crossorigin="anonymous" src="http://media.test/deny.png" alt="Anonymous CORS denied">
+            <video id="media-ok" controls preload="auto" crossorigin="anonymous" aria-hidden="true" src="http://media.test/ok.wav"></video>
+            <video id="media-deny" controls preload="auto" crossorigin="anonymous" src="http://media.test/deny.wav"></video>
+            """;
+        var clean = HtmlSanitizerHelper.Sanitize(html.Replace("http://media.test", media.Origin));
+        Assert.That(HtmlSanitizerHelper.Sanitize(clean), Is.EqualTo(clean));
+        await page.SetContentAsync(clean);
+        await page.AddStyleTagAsync(new()
+        {
+            Content = "body{font:16px sans-serif;margin:16px}h1{font-size:24px}img,video{display:block;margin:12px 0;max-width:100%}img{image-rendering:pixelated}"
+        });
+        await page.WaitForFunctionAsync("document.querySelector('#responsive').naturalWidth > 0 && document.querySelector('#fallback').naturalWidth > 0");
+        Assert.That(await page.Locator("#responsive").EvaluateAsync<string>("e => e.currentSrc"),
+            Does.EndWith("/fallback.png"));
+        Assert.That(await page.Locator("#fallback").EvaluateAsync<string>("e => e.currentSrc"), Does.EndWith("/fallback.png"));
+        Assert.That(await page.Locator("#decoration").EvaluateAsync<string>("e => getComputedStyle(e).textDecorationLine"), Is.EqualTo("line-through"));
+        await page.WaitForFunctionAsync("document.querySelector('#cors-ok').complete && document.querySelector('#cors-deny').complete");
+        Assert.That(await page.Locator("#cors-ok").EvaluateAsync<int>("e => e.naturalWidth"), Is.GreaterThan(0));
+        Assert.That(await page.Locator("#cors-deny").EvaluateAsync<int>("e => e.naturalWidth"), Is.Zero);
+        const string mediaSettled = "document.querySelector('#media-ok').readyState >= 1 && (document.querySelector('#media-deny').error !== null || document.querySelector('#media-deny').readyState >= 1)";
+        const string mediaState = "JSON.stringify([...document.querySelectorAll('video')].map(e => ({loaded:e.readyState >= 1, error:e.error?.code ?? null})))";
+        await page.WaitForFunctionAsync(mediaSettled);
+        var baseline = await context.NewPageAsync();
+        await baseline.GotoAsync(site.Origin);
+        await baseline.SetContentAsync($"""
+            <video id="media-ok" preload="auto" crossorigin="anonymous" src="{media.Origin}/ok.wav"></video>
+            <video id="media-deny" preload="auto" crossorigin="anonymous" src="{media.Origin}/deny.wav"></video>
+            """);
+        await baseline.WaitForFunctionAsync(mediaSettled);
+        var baselineState = await baseline.EvaluateAsync<string>(mediaState);
+        var actualState = await page.EvaluateAsync<string>(mediaState);
+        Assert.That(actualState, Is.EqualTo(baselineState), "Sanitization must preserve native media CORS behavior");
+        // Some Windows WebKit builds load cross-origin media even with anonymous CORS.
+        // Compare against raw markup, and check the fetch/image CORS boundary independently.
+        Assert.That(await page.EvaluateAsync<bool>("url => fetch(url).then(() => false, () => true)", $"{media.Origin}/deny.wav"), Is.True);
+        if (engine != "webkit")
+            Assert.That(await page.Locator("#media-deny").EvaluateAsync<bool>("e => e.error !== null"), Is.True);
+        TestContext.Progress.WriteLine($"{engine}/{width}: raw={baselineState}; sanitized={actualState}");
+        Assert.That(await page.Locator("#media-ok").EvaluateAsync<string>("e => e.crossOrigin"), Is.EqualTo("anonymous"));
+        Assert.That(await page.Locator("#media-ok").GetAttributeAsync("aria-hidden"), Is.Null);
+        await page.Locator("#media-ok").EvaluateAsync("e => { e.muted = true; return e.play(); }");
+        await page.WaitForFunctionAsync("document.querySelector('#media-ok').currentTime > 0");
+        var screenshots = Environment.GetEnvironmentVariable("HTML_SANITIZER_SCREENSHOTS");
+        if (!string.IsNullOrEmpty(screenshots))
+        {
+            Directory.CreateDirectory(screenshots);
+            await page.ScreenshotAsync(new() { Path = Path.Combine(screenshots, $"{engine}-{width}.png"), FullPage = true });
+            await File.WriteAllTextAsync(Path.Combine(screenshots, $"{engine}-{width}-aria.txt"),
+                await page.Locator("body").AriaSnapshotAsync());
+            await File.WriteAllTextAsync(Path.Combine(screenshots, $"{engine}-{width}-media.txt"),
+                $"raw={baselineState}\nsanitized={actualState}\n");
+        }
+        foreach (var candidate in new[] { "java&#x09;script:alert(1) 1x, /large.png 2x", "/bad.png 2q, /large.png 2x" })
+        {
+            requests.Clear();
+            await page.SetContentAsync(HtmlSanitizerHelper.Sanitize($"<img srcset='{candidate}' src='/fallback.png'>"));
+            await page.WaitForFunctionAsync("document.querySelector('img').complete && document.querySelector('img').naturalWidth > 0");
+            Assert.That(await page.Locator("img").EvaluateAsync<string>("e => e.currentSrc"), Does.EndWith("/fallback.png"));
+            Assert.That(requests, Does.Not.Contain("/1x"));
+        }
+    }
+}

--- a/CnGalWebSite/CnGalWebSite.UnitTest/HtmlSanitizerTests.cs
+++ b/CnGalWebSite/CnGalWebSite.UnitTest/HtmlSanitizerTests.cs
@@ -1,0 +1,165 @@
+using AngleSharp.Dom;
+using AngleSharp.Html.Parser;
+using CnGalWebSite.APIServer.Application.Helper;
+using Markdig;
+using NUnit.Framework;
+
+namespace CnGalWebSite.UnitTest;
+
+[TestFixture]
+public class HtmlSanitizerTests
+{
+    [TestCase("article"), TestCase("aside"), TestCase("footer"), TestCase("header")]
+    [TestCase("main"), TestCase("nav"), TestCase("section")]
+    public void PreservesSemanticContainerContent(string tag)
+    {
+        var body = Clean($"<{tag}><h2>Title</h2><p>Body &amp; text</p>"
+            + $"<img src='/ok.png' onerror='alert(1)'><script>alert(1)</script></{tag}>");
+        Assert.That(body.QuerySelector(tag)!.TextContent, Is.EqualTo("TitleBody & text"));
+        Assert.That(body.QuerySelector("img")!.GetAttribute("src"), Is.EqualTo("/ok.png"));
+        Assert.That(body.QuerySelectorAll("script,[onerror]"), Is.Empty);
+    }
+
+    [TestCase("HTTPS://PLAYER.BILIBILI.COM/player.html", true)]
+    [TestCase("//player.bilibili.com/player.html", true)]
+    [TestCase("https://b23.tv/example", true)]
+    [TestCase("https://bilibili.com:443/", true)]
+    [TestCase("https://evilbilibili.com/", false)]
+    [TestCase("https://bilibili.com.evil.example/", false)]
+    [TestCase("https://bilibili.com@evil.example/", false)]
+    [TestCase("https://evil.example@bilibili.com/", false)]
+    [TestCase("https://bilibili.com:444/", false)]
+    [TestCase("https://bilibili.com./", false)]
+    [TestCase("https://bilibili.com\\@evil.example/", false)]
+    [TestCase("https://bili&#9;bili.com/", false)]
+    [TestCase("https://bilibili.com&#10;@evil.example/", false)]
+    [TestCase("https://%62ilibili.com/", false)]
+    public void EnforcesInitialIframeOrigin(string url, bool allowed)
+    {
+        var frame = Clean($"<iframe src='{url}'></iframe>").QuerySelector("iframe");
+        Assert.That(frame != null, Is.EqualTo(allowed));
+        if (!allowed) return;
+        Assert.That(frame!.GetAttribute("loading"), Is.EqualTo("lazy"));
+        Assert.That(frame.GetAttribute("allow"), Is.EqualTo("fullscreen"));
+        Assert.That(frame.GetAttribute("referrerpolicy"), Is.EqualTo("strict-origin-when-cross-origin"));
+    }
+
+    private static IElement Clean(string html)
+    {
+        var result = HtmlSanitizerHelper.Sanitize(html);
+        Assert.That(HtmlSanitizerHelper.Sanitize(result), Is.EqualTo(result), "Idempotence");
+        return new HtmlParser().ParseDocument(result).Body!;
+    }
+
+    [TestCase("line-through")]
+    [TestCase("underline")]
+    public void PreservesTextDecoration(string value)
+    {
+        var body = Clean($"<span style='text-decoration:{value};position:fixed'>text</span>");
+        Assert.That(body.QuerySelector("span")!.GetAttribute("style"), Does.Contain(value).And.Not.Contain("position"));
+    }
+
+    [Test]
+    public void PreservesMarkdownAndSafeFormatting()
+    {
+        var markdown = "~~deleted~~\n\n- [x] done\n- [ ] todo\n\n| A | B |\n| :--- | ---: |\n| a | b |";
+        var body = Clean(Markdown.ToHtml(markdown, new MarkdownPipelineBuilder().UseAdvancedExtensions().Build()));
+        Assert.That(body.QuerySelector("del")!.TextContent, Is.EqualTo("deleted"));
+        Assert.That(body.QuerySelectorAll("input[disabled]"), Has.Length.EqualTo(2));
+        Assert.That(body.QuerySelectorAll("input[checked]"), Has.Length.EqualTo(1));
+        Assert.That(body.QuerySelector("th")!.GetAttribute("style"), Does.Contain("left"));
+        var colors = Clean("<span style='color:red;background-color:yellow;font-weight:bold;font-style:italic'>text</span>");
+        Assert.That(colors.QuerySelector("span")!.GetAttribute("style"),
+            Does.Contain("color").And.Contain("background-color").And.Contain("bold").And.Contain("italic"));
+    }
+
+    [TestCase("/small.png 1x, //cdn.example/large.png 2x")]
+    [TestCase("small.png 400w, https://cdn.example/large.png 800w")]
+    [TestCase("https://cdn.example/a,b.png 1x, /large.png 2x")]
+    public void KeepsFallbackWhileSrcsetSupportIsDeferred(string value)
+    {
+        var body = Clean($"<picture><source srcset='{value}' sizes='50vw'><img src='/fallback.png'></picture>");
+        var source = body.QuerySelector("source")!;
+        Assert.That(source.HasAttribute("srcset"), Is.False);
+        Assert.That(source.HasAttribute("sizes"), Is.False);
+        Assert.That(body.QuerySelector("img")!.GetAttribute("src"), Is.EqualTo("/fallback.png"));
+    }
+
+    [TestCase("javascript:alert(1)")]
+    [TestCase("JaVaScRiPt:alert(1)")]
+    [TestCase("java&#x09;script:alert(1)")]
+    [TestCase("java&#x0a;script:alert(1)")]
+    [TestCase("&#106;avascript:alert(1)")]
+    [TestCase("data:image/png;base64,AAAA")]
+    [TestCase("blob:https://example.com/id")]
+    [TestCase("mailto:test@example.com")]
+    [TestCase("file:///test.png")]
+    public void RemovesUnsafeCandidatesInEveryPosition(string url)
+    {
+        foreach (var candidates in new[] { $"{url} 1x, /ok.png 2x", $"/ok.png 1x, {url} 2x" })
+        {
+            var image = Clean($"<img srcset='{candidates}'>").QuerySelector("img")!;
+            Assert.That(image.HasAttribute("srcset"), Is.False);
+        }
+        var body = Clean($"<picture><source srcset='{url} 1x'><img src='/fallback.png'></picture>");
+        Assert.That(body.QuerySelector("source")!.HasAttribute("srcset"), Is.False);
+        Assert.That(body.QuerySelector("img")!.GetAttribute("src"), Is.EqualTo("/fallback.png"));
+    }
+
+    [Test]
+    public void RejectsMalformedDescriptorsAndRestrictsAttributeOwners()
+    {
+        var body = Clean("<img srcset='/bad.png 2q, /ok.png 2x'>"
+            + "<div srcset='/bad.png' sizes='100vw' crossorigin='anonymous'>text</div>"
+            + "<video><source src='/ok.mp4' srcset='/bad.png' sizes='100vw'></video>");
+        Assert.That(body.QuerySelector("img")!.HasAttribute("srcset"), Is.False);
+        Assert.That(body.QuerySelectorAll("div[srcset],div[sizes],div[crossorigin],video source[srcset],video source[sizes]"), Is.Empty);
+    }
+
+    [TestCase("img")]
+    [TestCase("source")]
+    [TestCase("audio")]
+    [TestCase("video")]
+    public void MediaSchemesAreNarrowerThanLinkSchemes(string tag)
+    {
+        foreach (var url in new[] { "mailto:test@example.com", "javascript:alert(1)", "java&#x09;script:alert(1)",
+            "java&#x0a;script:alert(1)", "&#106;avascript:alert(1)", "data:text/plain,test", "blob:https://example.com/id" })
+            Assert.That(Clean($"<{tag} src='{url}' poster='{url}'></{tag}>").QuerySelectorAll("[src],[poster]"), Is.Empty);
+        foreach (var url in new[] { "/ok.png", "../ok.png", "//cdn.example/ok.png", "https://cdn.example/ok.png", "http://cdn.example/ok.png" })
+            Assert.That(Clean($"<{tag} src='{url}'></{tag}>").QuerySelector(tag)!.GetAttribute("src"), Is.EqualTo(url));
+        Assert.That(Clean("<a href='mailto:test@example.com'>mail</a>").QuerySelector("a")!.GetAttribute("href"), Is.EqualTo("mailto:test@example.com"));
+    }
+
+    [TestCase("")]
+    [TestCase("anonymous")]
+    [TestCase("ANONYMOUS")]
+    public void NormalizesAnonymousCrossOrigin(string value)
+    {
+        foreach (var tag in new[] { "img", "audio", "video" })
+            Assert.That(Clean($"<{tag} crossorigin='{value}'></{tag}>").QuerySelector(tag)!.GetAttribute("crossorigin"), Is.EqualTo("anonymous"));
+    }
+
+    [TestCase("use-credentials")]
+    [TestCase("invalid")]
+    [TestCase(" anonymous ")]
+    public void RemovesUnsupportedCrossOrigin(string value)
+    {
+        Assert.That(Clean($"<video crossorigin='{value}'></video>").QuerySelectorAll("[crossorigin]"), Is.Empty);
+    }
+
+    [Test]
+    public void PreservesSecurityBoundaries()
+    {
+        var body = Clean("<script>alert(1)</script><img src='/ok.png' onerror='alert(1)'>"
+            + "<span style='color:red;background-image:url(javascript:alert(1));position:fixed'>text</span>"
+            + "<iframe src='https://evilbilibili.com/player' srcdoc='<script>alert(1)</script>'></iframe>"
+            + "<iframe src='//player.bilibili.com/player.html' srcdoc='bad'></iframe>"
+            + "<input type='text'><input type='checkbox' checked onclick='alert(1)'>"
+            + "<video aria-hidden='true'></video><a href='https://example.com' target='_blank'>link</a>");
+        Assert.That(body.QuerySelectorAll("script,[onerror],[onclick],[srcdoc],[aria-hidden],input[type=text]"), Is.Empty);
+        Assert.That(body.QuerySelectorAll("iframe"), Has.Length.EqualTo(1));
+        Assert.That(body.QuerySelector("iframe")!.GetAttribute("src"), Does.StartWith("https://player.bilibili.com/"));
+        Assert.That(body.QuerySelector("span")!.GetAttribute("style"), Does.Not.Contain("url").And.Not.Contain("position"));
+        Assert.That(body.QuerySelector("a")!.GetAttribute("rel"), Is.EqualTo("noopener noreferrer"));
+    }
+}


### PR DESCRIPTION
- 统一在服务端对文章、词条、抽奖等富文本进行白名单过滤
- 限制媒体 URL、iframe 来源及 crossorigin 属性取值
- 保留删除线等常用样式，并继续禁用存在风险的 srcset
- 使用 sandbox 隔离自定义 HTML 预览
- 优化 iframe 和音视频内容的响应式显示
- 补充安全过滤及跨浏览器回归测试