### PR TITLE
feat(mainsite): 接入 Umami 自定义埋点

### DIFF
--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/DesignSystem/CgCarousel.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/DesignSystem/CgCarousel.razor
@@ -22,7 +22,8 @@
                    href="@solo.Link"
                    target="@(IsExternalLink(solo.Link) ? "_blank" : null)"
                    rel="@(IsExternalLink(solo.Link) ? "noopener noreferrer" : null)"
-                   aria-label="@solo.Alt">
+                   aria-label="@solo.Alt"
+                   data-cg-track-slot="@TrackSlot">
                     <img class="cg-carousel__image"
                          src="@solo.Image"
                          alt="@solo.Alt"
@@ -61,7 +62,8 @@
                            href="@item.Link"
                            target="@(IsExternalLink(item.Link) ? "_blank" : null)"
                            rel="@(IsExternalLink(item.Link) ? "noopener noreferrer" : null)"
-                           aria-label="@item.Alt">
+                           aria-label="@item.Alt"
+                           data-cg-track-slot="@TrackSlot">
                             <img class="cg-carousel__image"
                                  src="@item.Image"
                                  alt="@item.Alt"
@@ -127,6 +129,10 @@
     /// <summary>图片原始高度（性能提示）</summary>
     [Parameter]
     public int ImageHeight { get; set; } = 400;
+
+    /// <summary>点击埋点位（data-cg-track-slot），为空时不输出属性</summary>
+    [Parameter]
+    public string? TrackSlot { get; set; }
 
     /// <summary>轮播项数据模型</summary>
     public record CgCarouselItem(string Image, string? Link, string? Alt);

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Analytics/TrackingMeta.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Analytics/TrackingMeta.razor
@@ -1,0 +1,18 @@
+@if (!string.IsNullOrEmpty(Type) && !string.IsNullOrEmpty(Id))
+{
+    <span hidden data-cg-track-view
+          data-cg-track-type="@Type"
+          data-cg-track-id="@Id"
+          data-cg-track-name="@Name"></span>
+}
+@if (!string.IsNullOrEmpty(UserId))
+{
+    <span hidden data-cg-track-user data-cg-track-user-id="@UserId"></span>
+}
+
+@code {
+    [Parameter] public string Type { get; set; } = "";   // entry/article/video/tag/space/periphery/lottery/favorite-folder
+    [Parameter] public string? Id { get; set; }
+    [Parameter] public string? Name { get; set; }
+    [Parameter] public string? UserId { get; set; }      // "sub" claim
+}

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Entry/Detail/EntryOutlinkList.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Entry/Detail/EntryOutlinkList.razor
@@ -8,7 +8,7 @@
         var desc = GetExternalLinkDescription(item);
         
         <li>
-            <a href="@item.Link" target="_blank" rel="noopener noreferrer" class="entry-outlink-item">
+            <a href="@item.Link" target="_blank" rel="noopener noreferrer" class="entry-outlink-item" data-cg-track-slot="outlink" data-cg-track-name="@title">
                 <div class="entry-outlink-item-icon">
                     @if (string.IsNullOrWhiteSpace(GetExternalLinkImage(item.DisplayName)) == false)
                     {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeCarouselCard.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeCarouselCard.razor
@@ -1,7 +1,8 @@
 <li class="home-card home-banner">
     <a href="@Link"
        target="@(IsExternalLink(Link) ? "_blank" : null)"
-       rel="@(IsExternalLink(Link) ? "noopener noreferrer" : null)">
+       rel="@(IsExternalLink(Link) ? "noopener noreferrer" : null)"
+       data-cg-track-slot="carousel">
         <img src="@Image" alt="@Note" loading="lazy" decoding="async" />
     </a>
 </li>

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeHero.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeHero.razor
@@ -2,7 +2,7 @@
 @using static CnGalWebSite.MainSite.Shared.Components.DesignSystem.CgCarousel
 
 <section class="home-hero-section">
-    <CgCarousel Items="@MapToCarouselItems()" />
+    <CgCarousel Items="@MapToCarouselItems()" TrackSlot="carousel" />
 </section>
 
 @code {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeLinkCard.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeLinkCard.razor
@@ -1,5 +1,5 @@
 <li class="home-card @(CommunityStyle ? "home-card--community" : string.Empty)">
-    <a href="@Url" target="@Target" rel="noopener noreferrer">
+    <a href="@Url" target="@Target" rel="noopener noreferrer" data-cg-track-slot="link">
         @if (CommunityStyle)
         {
             <span class="home-card-community-icon @(GetToneClass())">

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeMobileButtonGroup.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeMobileButtonGroup.razor
@@ -5,7 +5,7 @@
         <div class="home-mobile-button-group">
             @foreach (var item in _items)
             {
-                <a href="@item.Url" class="home-mobile-button-item" aria-label="@item.Name" @onclick="@(()=>OnClick(item))" @onclick:preventDefault="@(item.Url == null)">
+                <a href="@item.Url" class="home-mobile-button-item" aria-label="@item.Name" data-cg-track-slot="button" @onclick="@(()=>OnClick(item))" @onclick:preventDefault="@(item.Url == null)">
                     <div class="home-mobile-button-icon" style="background-color: @item.BgColor; color: @item.Color;">
                         <CgMdiIcon Name="@item.Icon" aria-hidden="true" />
                     </div>
@@ -15,16 +15,16 @@
         </div>
 
         <div class="home-mobile-community-buttons">
-            <a href="http://qm.qq.com/cgi-bin/qm/qr?_wv=1027&k=xDiiz0aB6eQcfYQnflSsKgOstQYewx0H&authKey=lHTWqnaM07S7E28d97f5T7ZfbmI7qCW5B8MVxooKMz84GPs28O6vZ13W%2FZ8N4CIl&noverify=0&group_code=948774838" target="_blank" rel="noopener noreferrer" class="home-mobile-community-btn" style="background: #E9F7FE; color: #74CFFE;" aria-label="QQ群">
+            <a href="http://qm.qq.com/cgi-bin/qm/qr?_wv=1027&k=xDiiz0aB6eQcfYQnflSsKgOstQYewx0H&authKey=lHTWqnaM07S7E28d97f5T7ZfbmI7qCW5B8MVxooKMz84GPs28O6vZ13W%2FZ8N4CIl&noverify=0&group_code=948774838" target="_blank" rel="noopener noreferrer" class="home-mobile-community-btn" style="background: #E9F7FE; color: #74CFFE;" aria-label="QQ群" data-cg-track-slot="button-community">
                 <CgMdiIcon Name="mdiQqchat" />
             </a>
-            <a href="https://weibo.com/cngalorg" target="_blank" rel="noopener noreferrer" class="home-mobile-community-btn" style="background: #FEEEE6; color: #FE7A60;" aria-label="微博">
+            <a href="https://weibo.com/cngalorg" target="_blank" rel="noopener noreferrer" class="home-mobile-community-btn" style="background: #FEEEE6; color: #FE7A60;" aria-label="微博" data-cg-track-slot="button-community">
                 <CgMdiIcon Name="mdiSinaWeibo" />
             </a>
-            <a href="https://space.bilibili.com/145239325" target="_blank" rel="noopener noreferrer" class="home-mobile-community-btn" style="background: #FAC7D9; color: #ff385b;" aria-label="Bilibili">
+            <a href="https://space.bilibili.com/145239325" target="_blank" rel="noopener noreferrer" class="home-mobile-community-btn" style="background: #FAC7D9; color: #ff385b;" aria-label="Bilibili" data-cg-track-slot="button-community">
                 <CgMdiIcon Name="mdiTelevisionClassic" />
             </a>
-            <a href="https://www.xiaoheihe.cn/app/user/profile/30519991" target="_blank" rel="noopener noreferrer" class="home-mobile-community-btn" style="background: #C0C0C0; color: #424242;" aria-label="小黑盒">
+            <a href="https://www.xiaoheihe.cn/app/user/profile/30519991" target="_blank" rel="noopener noreferrer" class="home-mobile-community-btn" style="background: #C0C0C0; color: #424242;" aria-label="小黑盒" data-cg-track-slot="button-community">
                 <CgMdiIcon Name="mdiPackageVariant" />
             </a>
         </div>

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeNewsCard.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Components/Features/Home/HomeNewsCard.razor
@@ -1,5 +1,5 @@
 <li class="home-news-card @(DevStyle ? "home-news-card--dev" : string.Empty)">
-    <a href="@Url" target="@Target" class="home-news-card-link">
+    <a href="@Url" target="@Target" class="home-news-card-link" data-cg-track-slot="news" data-cg-track-name="@Title">
         @if (!string.IsNullOrWhiteSpace(Image))
         {
             <div class="home-news-card-image">

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Layout/MainLayout.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Layout/MainLayout.razor
@@ -271,6 +271,7 @@
 <AuthorizeView>
     <Authorized>
         <KanbanToggleContainer />
+        <TrackingMeta UserId="@context.User.Claims.GetUserId()" />
         <CgToast @rendermode="InteractiveServer" />
         <CnGalWebSite.MainSite.Shared.Components.Layout.UserSessionTracker @rendermode="InteractiveServer" />
     </Authorized>

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Article/ArticleDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Article/ArticleDetailPage.razor
@@ -19,6 +19,7 @@
 @if (_model is not null)
 {
     <CgStructuredData Data="@GenerateStructuredDataJson()" />
+    <TrackingMeta Type="article" Id="@_model.Id.ToString()" Name="@_model.Name" />
 }
 
 @if (_errorMessage is not null)

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Entry/EntryDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Entry/EntryDetailPage.razor
@@ -25,6 +25,7 @@
 @if (Model is not null)
 {
     <CgStructuredData Data="@GenerateStructuredDataJson()" />
+    <TrackingMeta Type="entry" Id="@Model.Id.ToString()" Name="@Model.Name" />
 }
 
 @if (ErrorMessage is not null)

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/FavoriteFolder/FavoriteFolderDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/FavoriteFolder/FavoriteFolderDetailPage.razor
@@ -20,6 +20,7 @@
 else if (_model != null)
 {
     <CgPageMeta Title="@($"目录 - {_model.Name}")" Description="@(_model.BriefIntroduction)" Image="@(_model.MainPicture)" />
+    <TrackingMeta Type="favorite-folder" Id="@_model.Id.ToString()" Name="@_model.Name" />
 
     <article class="cg-ff-page">
         <FavoriteFolderHero Model="_model" />

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/CVThematicPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Home/CVThematicPage.razor
@@ -41,7 +41,8 @@
             {
                 <div class="cv-page__hero-col">
                     <CgCarousel Items="@MapToCarouselItems()"
-                                AspectRatio="4 / 3" />
+                                AspectRatio="4 / 3"
+                                TrackSlot="thematic" />
                 </div>
             }
         </div>

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Lottery/LotteryDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Lottery/LotteryDetailPage.razor
@@ -19,6 +19,8 @@
 }
 else if (_model is not null)
 {
+    <TrackingMeta Type="lottery" Id="@_model.Id.ToString()" Name="@_model.Name" />
+
     <article class="lottery-page">
         @if (HasAtmosphere())
         {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Periphery/PeripheryDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Periphery/PeripheryDetailPage.razor
@@ -22,6 +22,8 @@
 }
 else if (_model is not null)
 {
+    <TrackingMeta Type="periphery" Id="@_model.Id.ToString()" Name="@_model.Name" />
+
     <article class="periphery-page">
         @if (HasAtmosphere())
         {

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Space/SpaceIndexPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Space/SpaceIndexPage.razor
@@ -39,6 +39,7 @@ else if (_isNotFound)
 else if (_model != null)
 {
     <CgPageMeta Title="@($"{_model.Name} - 个人空间")" Description="@(_model.PersonalSignature)" Image="@(_model.PhotoPath)" />
+    <TrackingMeta Type="space" Id="@_model.Id" Name="@_model.Name" />
 
     <div class="cg-space-container">
         <div class="cg-space-layout-row">

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Tag/TagDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Tag/TagDetailPage.razor
@@ -11,6 +11,11 @@
 
 <CgPageMeta Title="@(_model?.Name)" Description="@(_model?.BriefIntroduction)" Image="@(_model?.MainPicture)" />
 
+@if (_model is not null)
+{
+    <TrackingMeta Type="tag" Id="@_model.Id.ToString()" Name="@_model.Name" />
+}
+
 @if (_errorMessage is not null)
 {
     <section class="tag-not-found">

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Video/VideoDetailPage.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/Pages/Video/VideoDetailPage.razor
@@ -19,6 +19,7 @@
 @if (Model is not null)
 {
     <CgStructuredData Data="@GenerateStructuredDataJson()" />
+    <TrackingMeta Type="video" Id="@Model.Id.ToString()" Name="@Model.Name" />
 }
 
 @if (ErrorMessage is not null)

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/_Imports.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/_Imports.razor
@@ -22,3 +22,4 @@
 @using CnGalWebSite.MainSite.Shared.Components.Features.Lottery.Draw
 @using CnGalWebSite.MainSite.Shared.Components.Features.Lottery.Detail
 @using CnGalWebSite.MainSite.Shared.Components.Features.Space
+@using CnGalWebSite.MainSite.Shared.Components.Features.Analytics

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/wwwroot/CnGalWebSite.MainSite.Shared.lib.module.js
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/wwwroot/CnGalWebSite.MainSite.Shared.lib.module.js
@@ -108,4 +108,11 @@ export function afterWebStarted(blazor) {
     });
     installImeInputListeners();
     document[installationKey] = true;
+
+    import('./scripts/umami-track.js')
+        .then(function (m) {
+            m.install();
+            blazor.addEventListener('enhancedload', function () { m.refresh(); });
+        })
+        .catch(function () { /* 埋点加载失败不影响页面 */ });
 }

--- a/CnGalWebSite/CnGalWebSite.MainSite.Shared/wwwroot/scripts/umami-track.js
+++ b/CnGalWebSite/CnGalWebSite.MainSite.Shared/wwwroot/scripts/umami-track.js
@@ -1,0 +1,166 @@
+/* 跨文件契约：TrackingMeta.razor 渲染 [data-cg-track-view]（data-cg-track-type/-id/-name）
+   与 [data-cg-track-user-id]；点击埋点锚点带 a[data-cg-track-slot]（可选 data-cg-track-name） */
+const maxQueueLength = 50;
+const maxWaitCount = 100;
+
+const queue = [];
+let waitCount = 0;
+let installed = false;
+let lastIdentifiedId = null;
+let lastNavMarkerKey = null;
+let renderedPage = null;
+
+function isReady() {
+    return window.umami != null
+        && typeof window.umami.track === 'function'
+        && typeof window.umami.identify === 'function';
+}
+
+function snapshotPage() {
+    return {
+        url: location.origin + location.pathname + location.hash,
+        title: document.title
+    };
+}
+
+function truncate(value) {
+    return value.length > 200 ? value.slice(0, 200) : value;
+}
+
+function sendEvent(name, data, page) {
+    submit({ kind: 'event', name: name, data: data, page: page });
+}
+
+function sendIdentify(userId) {
+    return submit({ kind: 'identify', id: userId });
+}
+
+function submit(item) {
+    if (isReady()) {
+        flushQueue();
+        dispatch(item);
+        return true;
+    }
+    if (waitCount < maxWaitCount && queue.length < maxQueueLength) {
+        queue.push(item);
+        return true;
+    }
+    return false;
+}
+
+function syncIdentity() {
+    const element = document.querySelector('[data-cg-track-user-id]');
+    const userId = element ? element.getAttribute('data-cg-track-user-id') : null;
+    if (userId && userId !== lastIdentifiedId && sendIdentify(userId)) {
+        lastIdentifiedId = userId;
+    }
+}
+
+function sendContentView() {
+    const element = document.querySelector('[data-cg-track-view]');
+    const type = element ? element.getAttribute('data-cg-track-type') : null;
+    const id = element ? element.getAttribute('data-cg-track-id') : null;
+    if (!type || !id) {
+        lastNavMarkerKey = null;
+        return;
+    }
+    const key = type + '/' + id;
+    if (key === lastNavMarkerKey) {
+        return;
+    }
+    lastNavMarkerKey = key;
+    const name = element.getAttribute('data-cg-track-name') || '';
+    sendEvent('content_view', {
+        type: type,
+        id: id,
+        name: truncate(name),
+        path: location.pathname
+    }, snapshotPage());
+}
+
+function deriveName(anchor) {
+    const explicit = anchor.getAttribute('data-cg-track-name')
+        || anchor.getAttribute('aria-label');
+    if (explicit) {
+        return truncate(explicit);
+    }
+    const image = anchor.querySelector('img[alt]');
+    const alt = image ? image.getAttribute('alt') : null;
+    if (alt) {
+        return truncate(alt);
+    }
+    return truncate((anchor.textContent || '').trim());
+}
+
+function onClick(event) {
+    const target = event.target instanceof Element ? event.target : null;
+    const anchor = target ? target.closest('a[data-cg-track-slot]') : null;
+    if (!anchor) {
+        return;
+    }
+    const href = anchor.getAttribute('href') || '';
+    const eventName = /^(https?:)?\/\//i.test(href) ? 'outbound_click' : 'promo_click';
+    sendEvent(eventName, {
+        slot: anchor.getAttribute('data-cg-track-slot'),
+        url: truncate(href),
+        name: deriveName(anchor)
+    }, renderedPage);
+}
+
+function onPopState() {
+    history.replaceState(history.state, '', location.href);
+}
+
+function dispatch(item) {
+    try {
+        let result;
+        if (item.kind === 'identify') {
+            result = window.umami.identify(item.id);
+        } else {
+            result = window.umami.track(function (p) {
+                return { ...p, url: item.page.url, title: item.page.title, name: item.name, data: item.data };
+            });
+        }
+        Promise.resolve(result).catch(function () {});
+    } catch {
+    }
+}
+
+function flushQueue() {
+    while (queue.length > 0) {
+        dispatch(queue.shift());
+    }
+}
+
+function pollQueue() {
+    if (isReady()) {
+        flushQueue();
+        return;
+    }
+    waitCount++;
+    if (waitCount < maxWaitCount) {
+        setTimeout(pollQueue, 100);
+    } else {
+        queue.length = 0;
+        lastIdentifiedId = null;
+    }
+}
+
+export function install() {
+    if (installed) {
+        return;
+    }
+    installed = true;
+    renderedPage = snapshotPage();
+    document.addEventListener('click', onClick, true);
+    window.addEventListener('popstate', onPopState);
+    syncIdentity();
+    sendContentView();
+    setTimeout(pollQueue, 100);
+}
+
+export function refresh() {
+    renderedPage = snapshotPage();
+    syncIdentity();
+    sendContentView();
+}

--- a/CnGalWebSite/CnGalWebSite.MainSite/Components/App.razor
+++ b/CnGalWebSite/CnGalWebSite.MainSite/Components/App.razor
@@ -58,7 +58,7 @@
     <meta itemprop="name" content="@PageMetaService.Title" />
     <meta itemprop="image" content="@PageMetaService.Image" />
     <HeadOutlet/>
-    <script async src="https://umami.cngal.top/script.js" data-website-id="c190d5e2-f859-430c-8463-be388f6875b0"></script>
+    <script async src="https://umami.cngal.top/script.js" data-website-id="c190d5e2-f859-430c-8463-be388f6875b0" data-tag="mainsite" data-performance="true"></script>
     <script type="text/javascript">
         (function (c, l, a, r, i, t, y) {
             c[a] = c[a] || function () { (c[a].q = c[a].q || []).push(arguments) };


### PR DESCRIPTION
- 新增点击事件
- 支持用户身份识别、延迟上报队列及导航去重
- 补齐前进后退 PV，使用已渲染页面快照修正点击来源归因
- 启用新站流量标签、性能采集、DNT 和查询参数排除